### PR TITLE
tools: add ROCmFPX Hyperloom adapter

### DIFF
--- a/docs/rocmfpx/README.md
+++ b/docs/rocmfpx/README.md
@@ -34,6 +34,7 @@ individual block layout.
 - [Formats and compatibility](FORMATS.md)
 - [Quant mixing](QUANT-MIXING.md)
 - [Plugin and sidecar ABI](PLUGINS.md)
+- [Hyperloom adapter](../../tools/hyperloom/README.md)
 - [AMD support tiers](SUPPORT.md)
 - [Release process](RELEASES.md)
 - Existing detailed benchmark and handoff documents in `docs/ROCmFP*.md`

--- a/tools/hyperloom/README.md
+++ b/tools/hyperloom/README.md
@@ -1,0 +1,82 @@
+# ROCmFPX Hyperloom adapter
+
+This directory connects ROCmFPX to Hyperloom's `custom` framework mode. It is
+development tooling and is not loaded by `llama-cli`, `llama-server`, or the
+ROCmFPX plugin ABI.
+
+Hyperloom writes accepted candidates as commits. Always give it a disposable
+worktree on an unprotected feature branch. `launch.sh` refuses `main`, `master`,
+upstream integration branches, and ROCmFPX upstream maintenance branches.
+
+## Support status
+
+- The benchmark contract supports decode, prefill, and native MTP objectives.
+- The quality gate requires exact deterministic output and an unchanged GGUF
+  file size.
+- The initial gfx1151 lane uses Hyperloom's framework agent with kernel and
+  roofline phases disabled.
+- Single-node gfx1151 runs default to local execution instead of Ray; set
+  `INFERENCE_OPTIMIZER_RAY_EXEC=1` only after qualifying a Ray deployment.
+- `HYPERLOOM_EXPERIMENTAL_RDNA_KERNELS=1` opts into the unqualified kernel lane.
+  GEAK is currently documented for AMD Instinct CDNA GPUs, so this is not a
+  supported default for RDNA.
+- Vulkan remains a separate release gate. Hyperloom's kernel tools currently
+  target HIP, Triton, and FlyDSL rather than Vulkan shaders.
+
+## Create the immutable quality reference
+
+Build the exact baseline first, then write the reference outside the source
+worktree:
+
+```bash
+export FRAMEWORK_REPO_PATH=/path/to/disposable/ROCmFPX
+export MODEL_PATH=/absolute/path/to/model.gguf
+export RESULT_DIR=/tmp/rocmfpx-hyperloom-reference
+export ROCMFPX_QUALITY_REFERENCE=/absolute/path/outside/repo/quality-reference.json
+export ROCMFPX_CREATE_REFERENCE=1
+export ROCMFPX_OBJECTIVE=decode
+tools/hyperloom/custom_strixhalo.sh
+unset ROCMFPX_CREATE_REFERENCE
+```
+
+The reference records the deterministic output hash, model size, backend, and
+baseline commit. Do not regenerate it from a candidate that Hyperloom changed.
+Use the same no-spec reference for the MTP objective: this makes the exact hash
+gate detect speculative-decoding output drift instead of accepting a new MTP
+output as its own baseline.
+
+## Launch Hyperloom
+
+Install Hyperloom in a separate workspace and supply credentials through the
+agent's credential store or process environment. Never place API keys in this
+repository, command arguments, benchmark reports, containers, or checked-in
+environment files.
+
+The adapter is tested against Hyperloom commit
+`120cb3262087b667de758cb38b51a6a481c7068b` with the companion gfx1151 patch.
+Apply it before launch:
+
+```bash
+git -C "$HYPERLOOM_ROOT" checkout 120cb3262087b667de758cb38b51a6a481c7068b
+git -C "$HYPERLOOM_ROOT" apply --unidiff-zero /path/to/ROCmFPX/tools/hyperloom/patches/hyperloom-gfx1151.patch
+```
+
+The launcher fails before starting Hyperloom if this board mapping is absent.
+See [the patch notes](patches/README.md) for licensing and provenance.
+
+```bash
+export HYPERLOOM_ROOT=/path/to/Hyperloom
+export FRAMEWORK_REPO_PATH=/path/to/disposable/ROCmFPX
+export MODEL_PATH=/absolute/path/to/model.gguf
+export ROCMFPX_QUALITY_REFERENCE=/absolute/path/outside/repo/quality-reference.json
+export USER_DATA_PATH=/absolute/path/to/hyperloom-sessions
+export ROCMFPX_OBJECTIVE=decode
+tools/hyperloom/launch.sh
+```
+
+Run separate sessions with `ROCMFPX_OBJECTIVE=prefill` and
+`ROCMFPX_OBJECTIVE=mtp`. The gfx1151 defaults are
+`ROCMFPX_MTP_N_MAX=6`, `ROCMFPX_MTP_P_MIN=0.6`, and 256 generated tokens;
+override them to compare candidates, but require the no-spec output hash to
+remain unchanged. A candidate is not ready for promotion until the normal
+ROCmFPX CPU, HIP, Vulkan, plugin, MTP, and format-size gates also pass.

--- a/tools/hyperloom/custom_strixhalo.sh
+++ b/tools/hyperloom/custom_strixhalo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$script_dir/run_benchmark.py"

--- a/tools/hyperloom/launch.sh
+++ b/tools/hyperloom/launch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo="${FRAMEWORK_REPO_PATH:-$(cd -- "$script_dir/../.." && pwd -P)}"
+model="${MODEL_PATH:?MODEL_PATH is required}"
+reference="${ROCMFPX_QUALITY_REFERENCE:?ROCMFPX_QUALITY_REFERENCE is required}"
+hyperloom_root="${HYPERLOOM_ROOT:?HYPERLOOM_ROOT is required}"
+hyperloom_python="${HYPERLOOM_PYTHON:-python3}"
+max_hours="${HYPERLOOM_MAX_HOURS:-12}"
+branch="$(git -C "$repo" branch --show-current)"
+patch_path="$script_dir/patches/hyperloom-gfx1151.patch"
+
+case "$branch" in
+    main|master|integration/*|rocmfpx/upstream-*)
+        echo "Refusing to run Hyperloom on protected branch: $branch" >&2
+        exit 2
+        ;;
+esac
+
+if [[ "$reference" == "$repo"/* ]]; then
+    echo "ROCMFPX_QUALITY_REFERENCE must be outside the source worktree" >&2
+    exit 2
+fi
+
+if [[ ! -f "$reference" ]]; then
+    echo "Missing quality reference: $reference" >&2
+    exit 2
+fi
+
+if ! PYTHONPATH="$hyperloom_root/src${PYTHONPATH:+:$PYTHONPATH}" "$hyperloom_python" -c 'from hyperloom.common.gpu_identity import AMD_GPU_DISPATCH_IDENTITIES; assert AMD_GPU_DISPATCH_IDENTITIES.get("strixhalo") == ("gfx1151", 40)' >/dev/null 2>&1; then
+    echo "Hyperloom does not have the required strixhalo/gfx1151 mapping." >&2
+    echo "Apply $patch_path to the pinned Hyperloom checkout; see $script_dir/patches/README.md" >&2
+    exit 2
+fi
+
+args=(
+    -m hyperloom.inference_optimizer.cli -v optimize
+    --framework custom
+    --framework-path "$repo"
+    --benchmark-scripts-dir "$script_dir"
+    --model "$model"
+    --gpu-type strixhalo
+    --tp 1
+    --max-hours "$max_hours"
+    --extra-env "ROCMFPX_BACKEND=${ROCMFPX_BACKEND:-ROCm0}"
+    --extra-env "ROCMFPX_BATCH=${ROCMFPX_BATCH:-2048}"
+    --extra-env "ROCMFPX_BUILD_DIR=${ROCMFPX_BUILD_DIR:-$repo/build-hyperloom}"
+    --extra-env "ROCMFPX_OBJECTIVE=${ROCMFPX_OBJECTIVE:-decode}"
+    --extra-env "ROCMFPX_QUALITY_REFERENCE=$reference"
+    --extra-env "ROCMFPX_REPETITIONS=${ROCMFPX_REPETITIONS:-3}"
+    --extra-env "ROCMFPX_MTP_N_MAX=${ROCMFPX_MTP_N_MAX:-6}"
+    --extra-env "ROCMFPX_MTP_P_MIN=${ROCMFPX_MTP_P_MIN:-0.6}"
+    --extra-env "ROCMFPX_MTP_TOKENS=${ROCMFPX_MTP_TOKENS:-256}"
+    --extra-env "ROCMFPX_UBATCH=${ROCMFPX_UBATCH:-512}"
+)
+
+if [[ -n "${ROCM_PATH:-}" ]]; then
+    args+=(--extra-env "ROCM_PATH=$ROCM_PATH")
+fi
+if [[ "${ROCMFPX_SKIP_BUILD:-0}" == 1 ]]; then
+    args+=(--extra-env "ROCMFPX_SKIP_BUILD=1")
+fi
+
+if [[ "${HYPERLOOM_EXPERIMENTAL_RDNA_KERNELS:-0}" != 1 ]]; then
+    args+=(--no-kernel --no-enable-roofline)
+fi
+
+export HYPERLOOM_BENCHMARK_BACKEND=bypass
+export HYPERLOOM_KERNEL_AGENT_ROOT="${HYPERLOOM_KERNEL_AGENT_ROOT:-$hyperloom_root/src/hyperloom/agents/kernel}"
+export HYPERLOOM_SPECIALIST_INHERIT_SECRET_ENV="${HYPERLOOM_SPECIALIST_INHERIT_SECRET_ENV:-0}"
+export INFERENCE_OPTIMIZER_RAY_EXEC="${INFERENCE_OPTIMIZER_RAY_EXEC:-0}"
+export PYTHONPATH="$hyperloom_root/src${PYTHONPATH:+:$PYTHONPATH}"
+exec "$hyperloom_python" "${args[@]}"

--- a/tools/hyperloom/patches/README.md
+++ b/tools/hyperloom/patches/README.md
@@ -1,0 +1,17 @@
+# Hyperloom gfx1151 compatibility patch
+
+`hyperloom-gfx1151.patch` targets AMD-AGI/Hyperloom commit
+`120cb3262087b667de758cb38b51a6a481c7068b`. It adds the `strixhalo` board
+identity, gfx1151 runner mapping, Radeon 8060S product aliases, and focused
+tests required by the ROCmFPX custom framework adapter.
+
+Hyperloom remains a separate project under its own Apache-2.0 license. The
+patch does not vendor Hyperloom into ROCmFPX. Review Hyperloom's license before
+redistributing a patched Hyperloom build.
+
+Apply the patch to the pinned checkout:
+
+```bash
+git -C "$HYPERLOOM_ROOT" checkout 120cb3262087b667de758cb38b51a6a481c7068b
+git -C "$HYPERLOOM_ROOT" apply --unidiff-zero /path/to/ROCmFPX/tools/hyperloom/patches/hyperloom-gfx1151.patch
+```

--- a/tools/hyperloom/patches/hyperloom-gfx1151.patch
+++ b/tools/hyperloom/patches/hyperloom-gfx1151.patch
@@ -1,0 +1,51 @@
+diff --git a/src/hyperloom/common/gpu_identity.py b/src/hyperloom/common/gpu_identity.py
+index 669f89cb..b294de87 100644
+--- a/src/hyperloom/common/gpu_identity.py
++++ b/src/hyperloom/common/gpu_identity.py
+@@ -22,0 +23 @@ AMD_GPU_DISPATCH_IDENTITIES: dict[str, tuple[str, int]] = {
++    "strixhalo": ("gfx1151", 40),
+diff --git a/src/hyperloom/inference_optimizer/gpu_types.py b/src/hyperloom/inference_optimizer/gpu_types.py
+index fcbf98fe..89bf633b 100644
+--- a/src/hyperloom/inference_optimizer/gpu_types.py
++++ b/src/hyperloom/inference_optimizer/gpu_types.py
+@@ -20,0 +21,5 @@ _PRODUCT_TAGS: tuple[str, ...] = tuple(sorted((t.upper() for t in _AMD_GPU_TYPES
++_PRODUCT_ALIASES: dict[str, str] = {
++    "RADEON 8060S": "strixhalo",
++    "RYZEN AI MAX+ 395": "strixhalo",
++}
++
+@@ -28,0 +34 @@ _GFX_TO_RUNNER: dict[str, str] = {
++    "gfx1151": "strixhalo",
+@@ -62 +68 @@ def _autodetect_gpu_type() -> str | None:
+-    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable."""
++    """Return a supported AMD board type, or None if undetectable."""
+@@ -74,0 +81,3 @@ def _autodetect_gpu_type() -> str | None:
++        for product, gpu_type in _PRODUCT_ALIASES.items():
++            if product in out:
++                return gpu_type
+diff --git a/src/hyperloom/inference_optimizer/tests/test_gpu_board_list_single_source.py b/src/hyperloom/inference_optimizer/tests/test_gpu_board_list_single_source.py
+index d6c48af2..7e02ebbb 100644
+--- a/src/hyperloom/inference_optimizer/tests/test_gpu_board_list_single_source.py
++++ b/src/hyperloom/inference_optimizer/tests/test_gpu_board_list_single_source.py
+@@ -16,0 +17,2 @@ from hyperloom.inference_optimizer.gpu_types import (
++    _GFX_TO_RUNNER,
++    _PRODUCT_ALIASES,
+@@ -17,0 +20 @@ from hyperloom.inference_optimizer.gpu_types import (
++    _autodetect_gpu_type,
+@@ -85,0 +89,16 @@ def test_a_tag_never_precedes_one_it_is_a_prefix_of():
++
++
++def test_strix_halo_dispatch_identity():
++    assert amd_gpu_dispatch_identity("strixhalo") == ("gfx1151", 40)
++    assert _GFX_TO_RUNNER["gfx1151"] == "strixhalo"
++
++
++def test_strix_halo_product_alias_autodetect(monkeypatch):
++    import subprocess
++
++    class Result:
++        stdout = "AMD RYZEN AI MAX+ 395 w/ Radeon 8060S"
++
++    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: Result())
++    assert _PRODUCT_ALIASES["RADEON 8060S"] == "strixhalo"
++    assert _autodetect_gpu_type() == "strixhalo"

--- a/tools/hyperloom/run_benchmark.py
+++ b/tools/hyperloom/run_benchmark.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+
+QUALITY_PROMPT = "Begin with ROCMFPX_QUALITY. State that seven times six is forty-two, then define a stack in one sentence."
+MTP_PROMPT = "Explain virtual memory briefly, then write a concise C++ function that reverses a singly linked list."
+PERF_RE = re.compile(r"Prompt:\s*([0-9.]+)\s*t/s\s*\|\s*Generation:\s*([0-9.]+)\s*t/s")
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def env_path(name: str, default: Path | None = None) -> Path:
+    value = os.environ.get(name)
+    if value:
+        return Path(value).expanduser().resolve()
+    if default is not None:
+        return default.resolve()
+    raise RuntimeError(f"{name} is required")
+
+
+def run(command: list[str], timeout: int, log_path: Path, input_text: str | None = None) -> str:
+    env = os.environ.copy()
+    completed = subprocess.run(
+        command,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        env=env,
+        check=False,
+    )
+    log_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode != 0:
+        raise RuntimeError(f"command failed with exit {completed.returncode}: {shlex.join(command)}")
+    return completed.stdout
+
+
+def configure_and_build(repo: Path, build_dir: Path, result_dir: Path) -> None:
+    if os.environ.get("ROCMFPX_SKIP_BUILD") == "1":
+        return
+
+    cmake_args = [
+        "cmake",
+        "-S",
+        str(repo),
+        "-B",
+        str(build_dir),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DGGML_HIP=ON",
+        "-DGGML_VULKAN=OFF",
+        "-DGGML_NATIVE=OFF",
+        "-DGGML_CCACHE=OFF",
+        "-DAMDGPU_TARGETS=gfx1151",
+    ]
+    rocm_path = os.environ.get("ROCM_PATH")
+    if rocm_path:
+        cmake_args.append(f"-DCMAKE_PREFIX_PATH={rocm_path}")
+        cmake_args.append(f"-DCMAKE_HIP_COMPILER={rocm_path}/bin/amdclang++")
+    cmake_args.extend(shlex.split(os.environ.get("ROCMFPX_CMAKE_ARGS", "")))
+    run(cmake_args, 600, result_dir / "configure.log")
+
+    jobs = int(os.environ.get("ROCMFPX_BUILD_JOBS", min(16, len(os.sched_getaffinity(0)))))
+    build_args = [
+        "cmake",
+        "--build",
+        str(build_dir),
+        "--target",
+        "llama-bench",
+        "llama-cli",
+        "-j",
+        str(jobs),
+    ]
+    run(build_args, 3600, result_dir / "build.log")
+
+
+def binary_path(build_dir: Path, name: str) -> Path:
+    override = os.environ.get(f"ROCMFPX_{name.upper().replace('-', '_')}")
+    path = Path(override).expanduser().resolve() if override else build_dir / "bin" / name
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise RuntimeError(f"missing executable: {path}")
+    return path
+
+
+def common_args(model: Path, backend: str) -> list[str]:
+    return [
+        "-m",
+        str(model),
+        "-dev",
+        backend,
+        "-ngl",
+        "999",
+        "-fa",
+        "on",
+    ]
+
+
+def speculation_args(backend: str) -> list[str]:
+    return [
+        "--spec-type",
+        "draft-mtp",
+        "--spec-draft-device",
+        backend,
+        "--spec-draft-ngl",
+        "all",
+        "--spec-draft-type-k",
+        "f16",
+        "--spec-draft-type-v",
+        "f16",
+        "--spec-draft-n-max",
+        os.environ.get("ROCMFPX_MTP_N_MAX", "6"),
+        "--spec-draft-n-min",
+        "0",
+        "--spec-draft-p-min",
+        os.environ.get("ROCMFPX_MTP_P_MIN", "0.6"),
+        "--spec-draft-backend-sampling",
+    ]
+
+
+def quality_output(cli: Path, model: Path, backend: str, result_dir: Path, use_mtp: bool) -> str:
+    command = [str(cli), *common_args(model, backend), "-c", "1024", "-b", "512", "-ub", "512"]
+    if use_mtp:
+        command.extend(speculation_args(backend))
+    command.extend(
+        [
+            "-st",
+            "--temp",
+            "0",
+            "--seed",
+            "1",
+            "-n",
+            "64",
+            "--reasoning",
+            "off",
+            "--no-display-prompt",
+            "--no-perf",
+            "--simple-io",
+            "--log-disable",
+            "-p",
+            QUALITY_PROMPT,
+        ]
+    )
+    output = run(command, 300, result_dir / "quality.log", input_text="")
+    normalized = ANSI_RE.sub("", output).replace("\r\n", "\n")
+    marker = f"> {QUALITY_PROMPT}"
+    if marker not in normalized:
+        raise RuntimeError("quality output does not contain the prompt marker")
+    generated = normalized.split(marker, 1)[1]
+    generated = re.split(r"\n\[ Prompt:", generated, maxsplit=1)[0]
+    return generated.strip()
+
+
+def load_json_lines(output: str) -> list[dict]:
+    rows: list[dict] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            rows.append(value)
+        elif isinstance(value, list):
+            rows.extend(item for item in value if isinstance(item, dict))
+    return rows
+
+
+def bench_metrics(bench: Path, model: Path, backend: str, result_dir: Path) -> dict[str, float]:
+    repetitions = os.environ.get("ROCMFPX_REPETITIONS", "3")
+    prompt_tokens = os.environ.get("ROCMFPX_PROMPT_TOKENS", "512")
+    generation_tokens = os.environ.get("ROCMFPX_GENERATION_TOKENS", "128")
+    command = [
+        str(bench),
+        *common_args(model, backend),
+        "-b",
+        os.environ.get("ROCMFPX_BATCH", "2048"),
+        "-ub",
+        os.environ.get("ROCMFPX_UBATCH", "512"),
+        "-p",
+        prompt_tokens,
+        "-n",
+        generation_tokens,
+        "-r",
+        repetitions,
+        "-o",
+        "jsonl",
+    ]
+    output = run(command, 1200, result_dir / "llama-bench.log")
+    rows = load_json_lines(output)
+    prompt = [float(row["avg_ts"]) for row in rows if int(row.get("n_prompt", 0)) > 0]
+    decode = [float(row["avg_ts"]) for row in rows if int(row.get("n_gen", 0)) > 0]
+    if not prompt or not decode:
+        raise RuntimeError("llama-bench did not emit prompt and generation JSON rows")
+    return {
+        "prefill_tokens_per_second": prompt[-1],
+        "decode_tokens_per_second": decode[-1],
+    }
+
+
+def mtp_metrics(cli: Path, model: Path, backend: str, result_dir: Path) -> dict[str, float]:
+    repetitions = int(os.environ.get("ROCMFPX_REPETITIONS", "3"))
+    prompt_rates: list[float] = []
+    decode_rates: list[float] = []
+    for index in range(repetitions):
+        command = [
+            str(cli),
+            *common_args(model, backend),
+            "-c",
+            "4096",
+            "-b",
+            os.environ.get("ROCMFPX_BATCH", "2048"),
+            "-ub",
+            os.environ.get("ROCMFPX_UBATCH", "512"),
+            *speculation_args(backend),
+            "-st",
+            "--simple-io",
+            "--temp",
+            "0",
+            "--seed",
+            "1",
+            "-n",
+            os.environ.get("ROCMFPX_MTP_TOKENS", "256"),
+            "--reasoning",
+            "off",
+            "-p",
+            MTP_PROMPT,
+        ]
+        output = run(command, 600, result_dir / f"mtp-{index + 1}.log", input_text="")
+        matches = PERF_RE.findall(ANSI_RE.sub("", output))
+        if not matches:
+            raise RuntimeError("llama-cli did not emit an MTP performance line")
+        prompt_rate, decode_rate = matches[-1]
+        prompt_rates.append(float(prompt_rate))
+        decode_rates.append(float(decode_rate))
+    return {
+        "prefill_tokens_per_second": statistics.median(prompt_rates),
+        "decode_tokens_per_second": statistics.median(decode_rates),
+        "decode_min_tokens_per_second": min(decode_rates),
+        "decode_max_tokens_per_second": max(decode_rates),
+    }
+
+
+def git_head(repo: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return completed.stdout.strip()
+
+
+def write_result(path: Path, report: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    rocm_path = os.environ.get("ROCM_PATH", "").strip()
+    if rocm_path:
+        os.environ["PATH"] = f"{rocm_path}/bin:{os.environ.get('PATH', '')}"
+        current_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+        os.environ["LD_LIBRARY_PATH"] = f"{rocm_path}/lib{':' + current_library_path if current_library_path else ''}"
+    repo = env_path("FRAMEWORK_REPO_PATH", Path(__file__).resolve().parents[2])
+    model = env_path("MODEL_PATH")
+    result_dir = env_path("RESULT_DIR")
+    result_dir.mkdir(parents=True, exist_ok=True)
+    result_filename = os.environ.get("RESULT_FILENAME", "inferencex_result")
+    result_path = result_dir / f"{result_filename}.json"
+    build_dir = env_path("ROCMFPX_BUILD_DIR", repo / "build-hyperloom")
+    backend = os.environ.get("ROCMFPX_BACKEND", "ROCm0")
+    objective = os.environ.get("ROCMFPX_OBJECTIVE", "decode").lower()
+    if objective not in {"decode", "prefill", "mtp"}:
+        raise RuntimeError("ROCMFPX_OBJECTIVE must be decode, prefill, or mtp")
+    if not model.is_file():
+        raise RuntimeError(f"missing model: {model}")
+
+    try:
+        configure_and_build(repo, build_dir, result_dir)
+        bench = binary_path(build_dir, "llama-bench")
+        cli = binary_path(build_dir, "llama-cli")
+        quality = quality_output(cli, model, backend, result_dir, objective == "mtp")
+        if not quality:
+            raise RuntimeError("quality command produced no captured output")
+        quality_hash = hashlib.sha256(quality.encode("utf-8")).hexdigest()
+        reference_path = env_path("ROCMFPX_QUALITY_REFERENCE")
+        create_reference = os.environ.get("ROCMFPX_CREATE_REFERENCE") == "1"
+
+        if create_reference:
+            if repo == reference_path or repo in reference_path.parents:
+                raise RuntimeError("quality reference must be outside the source worktree")
+            reference = {
+                "backend": backend,
+                "git_head": git_head(repo),
+                "model": str(model),
+                "model_size": model.stat().st_size,
+                "objective": objective,
+                "output_sha256": quality_hash,
+                "prompt": QUALITY_PROMPT,
+            }
+        else:
+            reference = json.loads(reference_path.read_text(encoding="utf-8"))
+        quality_passed = bool(quality) and quality_hash == reference.get("output_sha256")
+        quality_passed = quality_passed and model.stat().st_size == int(reference.get("model_size", -1))
+
+        metrics = (
+            mtp_metrics(cli, model, backend, result_dir)
+            if objective == "mtp"
+            else bench_metrics(bench, model, backend, result_dir)
+        )
+        if create_reference:
+            reference_path.parent.mkdir(parents=True, exist_ok=True)
+            reference_path.write_text(
+                json.dumps(reference, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        throughput = metrics[f"{objective if objective != 'mtp' else 'decode'}_tokens_per_second"]
+        report = {
+            "framework": "custom",
+            "workload_kind": "scriptable",
+            "throughput_unit": "tokens/s",
+            "output_throughput": throughput,
+            "quality_gate": {
+                "passed": quality_passed,
+                "expected_output_sha256": reference.get("output_sha256"),
+                "output_sha256": quality_hash,
+                "model_size_unchanged": model.stat().st_size == int(reference.get("model_size", -1)),
+            },
+            "rocmfpx": {
+                "backend": backend,
+                "git_head": git_head(repo),
+                "model_size": model.stat().st_size,
+                "objective": objective,
+                **metrics,
+            },
+        }
+        write_result(result_path, report)
+        return 0 if quality_passed else 3
+    except Exception as error:
+        write_result(
+            result_path,
+            {
+                "framework": "custom",
+                "workload_kind": "scriptable",
+                "throughput_unit": "tokens/s",
+                "output_throughput": 0.0,
+                "quality_gate": {"passed": False, "error": str(error)},
+            },
+        )
+        print(f"ROCmFPX Hyperloom benchmark failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a Hyperloom custom-framework adapter for ROCmFPX decode, prefill, and native MTP objectives
- add deterministic output and unchanged-GGUF-size gates
- add a pinned Hyperloom gfx1151 compatibility patch with Apache-2.0 provenance notes
- refuse protected ROCmFPX branches, fail fast on an unpatched Hyperloom checkout, disable RDNA kernel and roofline lanes by default, and use local execution by default on single-node gfx1151
- document credential handling without storing keys in the repository or benchmark artifacts

## Validation

- ROCm 10.0.0 HIP build on gfx1151: no-spec decode 14.03 tokens/s and PP512 411.45 tokens/s
- Hyperloom-controlled baseline and automatic profile pass completed with the exact-output gate
- MTP n-max 6 / p-min 0.6: 30.7 tokens/s median versus a matched 14.0 tokens/s no-spec control, a 119.3% uplift
- MTP output hash matched the no-spec reference and the GGUF size remained unchanged
- pinned Hyperloom patch applies cleanly and its focused test file passes 8 tests
- Python compilation, shell syntax, protected-branch refusal, transactional reference creation, whitespace checks, and changed-file credential scans passed

## Scope

This is development tooling only. It does not change llama.cpp runtime code or the Vulkan path. GEAK kernel rewriting and roofline profiling remain opt-in and unqualified on RDNA.

Assisted-by: Codex