### PR TITLE
ci: focus private fork validation

### DIFF
--- a/.github/workflows/check-rocmfpx.yml
+++ b/.github/workflows/check-rocmfpx.yml
@@ -12,6 +12,7 @@ on:
       - 'ggml/src/ggml.c'
       - 'ggml/src/ggml-cuda/**'
       - 'ggml/src/ggml-vulkan/**'
+      - 'extensions/rocmfpx-vulkan/**'
       - 'gguf-py/gguf/constants.py'
       - 'gguf-py/gguf/quants.py'
       - 'include/rocmfpx-plugin.h'
@@ -31,6 +32,8 @@ on:
       - 'scripts/check-release-recipe-map.py'
       - 'scripts/sweep-rocmfpx-*.sh'
       - 'scripts/build-rocmfpx-*.sh'
+      - 'scripts/rocmfpx/manage-actions-policy.sh'
+      - 'tools/hyperloom/**'
       - 'docs/recipes/**'
       - '.github/workflows/check-rocmfpx.yml'
   pull_request:
@@ -40,6 +43,7 @@ on:
       - 'ggml/src/ggml.c'
       - 'ggml/src/ggml-cuda/**'
       - 'ggml/src/ggml-vulkan/**'
+      - 'extensions/rocmfpx-vulkan/**'
       - 'gguf-py/gguf/constants.py'
       - 'gguf-py/gguf/quants.py'
       - 'include/rocmfpx-plugin.h'
@@ -59,8 +63,13 @@ on:
       - 'scripts/check-release-recipe-map.py'
       - 'scripts/sweep-rocmfpx-*.sh'
       - 'scripts/build-rocmfpx-*.sh'
+      - 'scripts/rocmfpx/manage-actions-policy.sh'
+      - 'tools/hyperloom/**'
       - 'docs/recipes/**'
       - '.github/workflows/check-rocmfpx.yml'
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -69,12 +78,13 @@ concurrency:
 jobs:
   rocmfpx-reference:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
       - name: Python converter smoke
         run: |
-          python3 -m py_compile convert_hf_to_gguf.py convert_modular.py conversion/base.py conversion/__init__.py conversion/gemma.py conversion/llama.py
+          python3 -m py_compile convert_hf_to_gguf.py convert_modular.py conversion/base.py conversion/__init__.py conversion/gemma.py conversion/llama.py tools/hyperloom/run_benchmark.py
           python3 - <<'PY'
           from pathlib import Path
 
@@ -86,21 +96,16 @@ jobs:
 
       - name: ROCmFPX script syntax
         run: |
-          for s in scripts/check-rocmfpx-*.sh scripts/sweep-rocmfpx-*.sh scripts/build-rocmfpx-*.sh; do
+          for s in scripts/check-rocmfpx-*.sh scripts/sweep-rocmfpx-*.sh scripts/build-rocmfpx-*.sh scripts/rocmfpx/manage-actions-policy.sh tools/hyperloom/*.sh; do
             bash -n "$s"
           done
 
       - name: Released model recipe map
         run: python3 scripts/check-release-recipe-map.py
 
-      - name: Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake
-
       - name: Build reference + backend ops
         run: |
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_UI=OFF
           cmake --build build --target test-backend-ops test-rocmfpx-plugin test-llama-archs -j 2
 
       - name: Reference probe

--- a/.github/workflows/rocmfpx-gfx1151.yml
+++ b/.github/workflows/rocmfpx-gfx1151.yml
@@ -1,0 +1,51 @@
+name: ROCmFPX gfx1151 qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      validate_w4a4:
+        description: Also build the opt-in ROCmI4 W4A4 profile
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rocmfpx-gfx1151
+  cancel-in-progress: false
+
+jobs:
+  qualify:
+    runs-on: [self-hosted, linux, x64, rocmfpx, gfx1151]
+    timeout-minutes: 180
+    env:
+      HSA_OVERRIDE_GFX_VERSION: 11.5.1
+      ROCM_PATH: /opt/rocm
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enforce private downstream and manual execution
+        shell: bash
+        run: |
+          test "$GITHUB_EVENT_NAME" = workflow_dispatch
+          test "${GITHUB_REPOSITORY,,}" = rocmfpx/rocmfpx
+          test "${{ github.event.repository.private }}" = true
+
+      - name: CPU, Vulkan, and HIP qualification
+        shell: bash
+        env:
+          BUILD_DIR: ${{ runner.temp }}/rocmfpx-validation
+          ROCMFPX_VALIDATE_VULKAN: 1
+          ROCMFPX_VALIDATE_HIP: 1
+          ROCMFPX_VALIDATE_W4A4: ${{ inputs.validate_w4a4 && '1' || '0' }}
+        run: scripts/rocmfpx/validate-sync.sh
+
+      - name: ROCmFP4 backend operation smoke
+        shell: bash
+        env:
+          BUILD_DIR: ${{ runner.temp }}/rocmfpx-validation
+        run: |
+          "$BUILD_DIR/vulkan/bin/test-backend-ops" test -b Vulkan0 -o MUL_MAT -p 'type_a=q4_0_rocmfp4,'
+          ./build-strix-rocmfpx/bin/test-backend-ops test -b ROCm0 -o MUL_MAT -p 'type_a=q4_0_rocmfp4,'

--- a/docs/rocmfpx/CI.md
+++ b/docs/rocmfpx/CI.md
@@ -1,0 +1,39 @@
+# ROCmFPX CI policy
+
+ROCmFPX keeps the upstream llama.cpp workflow files intact for easier upstream merges, but most inherited workflows are disabled in the private GitHub repository.
+Only these workflows remain enabled:
+
+- `check-rocmfpx.yml`: focused hosted CPU reference, format, plugin ABI, PLE, script, and converter checks for ROCmFPX paths.
+- `rocmfpx-gfx1151.yml`: manual-only Vulkan and HIP qualification on a dedicated self-hosted gfx1151 runner.
+- `rocmfpx-upstream-sync.yml`: weekly and manual upstream merge preparation.
+- `rocmfpx-release.yml`: manual or version-tag release packaging.
+
+This policy avoids running the full upstream CPU, Windows, CUDA, server, UI, WebGPU, and cross-platform matrices for every private downstream pull request.
+Disabled workflow source files continue to receive normal upstream merges and can be re-enabled temporarily when a cross-platform qualification is required.
+
+## Apply or inspect the policy
+
+The policy script verifies the exact private destination before changing workflow state.
+It uses the authenticated GitHub CLI session and never reads or stores a token itself.
+
+```bash
+scripts/rocmfpx/manage-actions-policy.sh --dry-run
+scripts/rocmfpx/manage-actions-policy.sh --apply
+scripts/rocmfpx/manage-actions-policy.sh --check
+```
+
+`--dry-run` reports drift and exits successfully, `--apply` reconciles workflow states, and `--check` returns nonzero when the GitHub configuration differs from the allowlist.
+Run the policy after the first private publication and after an upstream merge adds a workflow file.
+
+## Hosted and self-hosted work
+
+The focused reference check uses a GitHub-hosted Linux runner only when a pull request or push changes a ROCmFPX implementation path.
+The gfx1151 workflow has no push, pull request, or schedule trigger and therefore cannot start automatically.
+It requires a runner with the labels `self-hosted`, `linux`, `x64`, `rocmfpx`, and `gfx1151`.
+
+Treat a self-hosted runner as a code-execution boundary.
+Use a dedicated machine or isolated runner account, keep the repository private, never add a pull request trigger to the gfx1151 workflow, and review the selected commit before manual dispatch.
+Do not register the live inference host as a general-purpose runner while protected services are active.
+
+GitHub billing and budget controls belong to the repository owner account.
+Keeping a zero paid-overage budget prevents surprise hosted-runner charges but pauses hosted checks after the included allowance is exhausted.

--- a/docs/rocmfpx/README.md
+++ b/docs/rocmfpx/README.md
@@ -35,6 +35,7 @@ individual block layout.
 - [Quant mixing](QUANT-MIXING.md)
 - [Plugin and sidecar ABI](PLUGINS.md)
 - [Hyperloom adapter](../../tools/hyperloom/README.md)
+- [CI policy](CI.md)
 - [AMD support tiers](SUPPORT.md)
 - [Release process](RELEASES.md)
 - Existing detailed benchmark and handoff documents in `docs/ROCmFP*.md`

--- a/scripts/rocmfpx/manage-actions-policy.sh
+++ b/scripts/rocmfpx/manage-actions-policy.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=ROCmFPX/ROCmFPX
+mode=dry-run
+
+usage() {
+    echo "usage: $0 [--dry-run|--check|--apply] [--repo ROCmFPX/ROCmFPX]" >&2
+}
+
+while (($#)); do
+    case "$1" in
+        --dry-run)
+            mode=dry-run
+            shift
+            ;;
+        --check)
+            mode=check
+            shift
+            ;;
+        --apply)
+            mode=apply
+            shift
+            ;;
+        --repo)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            repo=$2
+            shift 2
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+[[ "$repo" == ROCmFPX/ROCmFPX ]] || {
+    echo "refusing workflow changes outside ROCmFPX/ROCmFPX" >&2
+    exit 2
+}
+
+command -v gh >/dev/null || {
+    echo "gh is required" >&2
+    exit 2
+}
+
+name=$(gh repo view "$repo" --json nameWithOwner --jq .nameWithOwner)
+private=$(gh repo view "$repo" --json isPrivate --jq .isPrivate)
+[[ "$name" == "$repo" && "$private" == true ]] || {
+    echo "refusing non-private or unexpected repository: $name" >&2
+    exit 2
+}
+
+declare -A keep=(
+    [.github/workflows/check-rocmfpx.yml]=1
+    [.github/workflows/rocmfpx-gfx1151.yml]=1
+    [.github/workflows/rocmfpx-release.yml]=1
+    [.github/workflows/rocmfpx-upstream-sync.yml]=1
+)
+declare -A seen=()
+
+changes=0
+while IFS=$'\t' read -r id path state; do
+    seen["$path"]=1
+    desired=disabled_manually
+    action=disable
+    if [[ ${keep[$path]:-0} == 1 ]]; then
+        desired=active
+        action=enable
+    fi
+
+    if [[ "$state" == "$desired" ]]; then
+        printf 'keep %-17s %s\n' "$state" "$path"
+        continue
+    fi
+
+    changes=$((changes + 1))
+    printf '%s %-14s %s (%s -> %s)\n' "$mode" "$action" "$path" "$state" "$desired"
+    if [[ "$mode" == apply ]]; then
+        gh api --method PUT "repos/$repo/actions/workflows/$id/$action" >/dev/null
+    fi
+done < <(gh api --paginate "repos/$repo/actions/workflows?per_page=100" --jq '.workflows[] | [.id, .path, .state] | @tsv')
+
+for path in "${!keep[@]}"; do
+    if [[ ${seen[$path]:-0} == 0 ]]; then
+        changes=$((changes + 1))
+        printf '%s missing        %s\n' "$mode" "$path"
+    fi
+done
+
+printf 'workflow policy changes: %d\n' "$changes"
+if [[ "$mode" == check && $changes -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- keep upstream llama.cpp workflow files intact while disabling inherited matrices at the repository workflow-state level
- narrow the hosted ROCmFPX reference check and add explicit permissions and timeouts
- add a manual-only gfx1151 Vulkan/HIP qualification workflow for a dedicated self-hosted runner
- document and automate the private-fork CI policy without storing credentials

## Local validation

- workflow YAML parse and shell/Python syntax checks
- release recipe map: 14 artifacts
- ROCmFP3/5/6/7/8 and ROCmI4 reference probes
- exhaustive ROCmFP2 phase-1 reference suite
- CPU backend ops: 2,829/2,829 passed
- plugin ABI CTest: passed
- qwen4exp architecture fixture: passed
- credential-pattern scan of committed files: clean

## Cost and runner behavior

The inherited upstream workflows were disabled before this PR was opened, so this PR should trigger only the focused ROCmFPX reference workflow. The gfx1151 workflow is manual-only and requires an explicitly labeled dedicated runner. GitHub-hosted execution may remain unavailable until the repository account billing/spending-limit condition is cleared; that is an account runner condition rather than a source-test failure.
