### PR TITLE
docs: explain Windows AMD multi-GPU bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ROCmFPX llama.cpp
 
-This private integration branch tracks current upstream `llama.cpp` while
+This public downstream tracks current upstream `llama.cpp` while
 developing the ROCmFPX weight-format family for AMD GPUs. Normal Vulkan support
 remains enabled; HIP and CPU are also supported build targets. Existing NVFP4
 GGUF tensors can be loaded natively and remain bit-exact when an NVFP4 model is
@@ -132,6 +132,35 @@ generation. Plugins run as native code with the same permissions as ROCmFPX,
 so load only libraries you trust. See the complete [plugin and sidecar ABI
 guide](docs/rocmfpx/PLUGINS.md) and the tested
 [`rocmfpx-test-plugin`](tests/rocmfpx-test-plugin.c) example.
+
+## Windows AMD multi-GPU bridge
+
+Windows users with two AMD GPUs can evaluate Charlie12345's external
+[Windows AMD Multi-GPU Bridge](https://github.com/charlie12345/windows-amd-vllm-multigpu).
+For ROCmFPX and llama.cpp, use its dedicated
+[Windows installation guide](https://github.com/charlie12345/windows-amd-vllm-multigpu/blob/main/docs/install-llama-rocmfpx.md),
+not the separate vLLM adapter instructions.
+
+The bridge keeps the ROCmFPX source tree unchanged. It supplies an external
+`roc::rccl` CMake package to the existing HIP collective interface, so build
+ROCmFPX with `GGML_HIP_RCCL=ON`, point `rccl_DIR` at the installed bridge, and
+use the bridge's `run-with-llama-plugin.ps1` launcher. The tested Windows path
+also requires `GGML_CUDA_NO_PEER_COPY=ON`; follow the external guide for the
+matching ROCm version, GPU target, DLL layout, health probes, and model-specific
+launch flags.
+
+Despite the launcher's name, this transport is **not** loaded through
+`ROCMFPX_PLUGIN_PATH` and is not a ROCmFPX ABI v1 plugin. ABI v1 can register a
+ggml backend or receive model lifecycle notifications, but it cannot inject a
+link-time RCCL provider or intercept collectives. Pointing
+`ROCMFPX_PLUGIN_PATH` at `rccl.dll` will therefore do nothing. The current
+external-package design is the upstream-safe integration: update ROCmFPX
+normally, then configure a fresh HIP build against the bridge package.
+
+The bridge is experimental, source-only, and currently qualified only on the
+hardware and revisions listed by its maintainers. Validate its small parity
+and transport probes before loading a large model; a selectable GPU target is
+not the same as a runtime-qualified configuration.
 
 ---
 

--- a/docs/rocmfpx/PLUGINS.md
+++ b/docs/rocmfpx/PLUGINS.md
@@ -117,6 +117,33 @@ logging, capability flags, and model callbacks. Its matching
 `tests/test-rocmfpx-plugin.cpp` exercises load deduplication, model open/close,
 and shutdown.
 
+## Windows AMD multi-GPU transport boundary
+
+Charlie12345's
+[Windows AMD Multi-GPU Bridge](https://github.com/charlie12345/windows-amd-vllm-multigpu)
+supports an external, source-clean ROCmFPX/llama.cpp integration. Its
+[`install-llama-rocmfpx.md`](https://github.com/charlie12345/windows-amd-vllm-multigpu/blob/main/docs/install-llama-rocmfpx.md)
+guide builds a six-symbol RCCL ABI shim and exposes it as a `roc::rccl` CMake
+package. ROCmFPX's HIP backend must be configured with `GGML_HIP_RCCL=ON` and
+linked against that package before it can use the transport.
+
+This is deliberately separate from plugin ABI v1:
+
+- `ROCMFPX_PLUGIN_PATH` libraries must export `rocmfpx_plugin_query`; the
+  bridge's `rccl.dll` exports the NCCL/RCCL symbols consumed by ggml HIP.
+- ABI v1 backend registration loads a complete standard ggml backend. It does
+  not replace a dependency inside an already-built HIP backend.
+- ABI v1 sidecar callbacks observe model open and close. They do not receive or
+  override collective operations.
+
+Do not rename or wrap `rccl.dll` and present it as an ABI v1 plugin. A future
+runtime adapter would need either a commit-matched HIP backend bundle registered
+as a standard ggml backend, or a new pre-backend collective-provider contract;
+a query-symbol wrapper alone cannot remove the `GGML_HIP_RCCL` build
+requirement. Until such an interface is implemented and qualified, the
+external CMake package plus its PowerShell launcher is the supported clean-tree
+route on Windows.
+
 ## Use the Charlie Vulkan backend plugin
 
 The in-tree [Charlie Vulkan extension](../../extensions/rocmfpx-vulkan/README.md)

--- a/docs/rocmfpx/README.md
+++ b/docs/rocmfpx/README.md
@@ -34,6 +34,7 @@ individual block layout.
 - [Formats and compatibility](FORMATS.md)
 - [Quant mixing](QUANT-MIXING.md)
 - [Plugin and sidecar ABI](PLUGINS.md)
+- [Windows AMD multi-GPU bridge](../../README.md#windows-amd-multi-gpu-bridge)
 - [Hyperloom adapter](../../tools/hyperloom/README.md)
 - [CI policy](CI.md)
 - [AMD support tiers](SUPPORT.md)


### PR DESCRIPTION
## Summary

- add a Windows AMD multi-GPU section linking Charlie12345's external bridge and its ROCmFPX/llama.cpp guide
- distinguish the external `roc::rccl` CMake integration from the ROCmFPX ABI v1 `ROCMFPX_PLUGIN_PATH` loader
- add the guide to the ROCmFPX documentation index and update the stale private-repository wording

## Compatibility boundary

The current bridge keeps the ROCmFPX source tree clean through upstream's `GGML_HIP_RCCL`/`rccl_DIR` build interface. It does not export `rocmfpx_plugin_query`, and ABI v1 has no collective interception hook, so the documentation does not claim that `rccl.dll` is already a runtime ABI plugin.

This PR changes documentation only. It does not alter model formats, backends, plugin ABI, or build defaults.

## Validation

- `git diff --check`
- both external documentation links return HTTP 200
- verified the bridge exports the expected six NCCL/RCCL symbols and no `rocmfpx_plugin_query` symbol
