### PR TITLE
fix(rocmfpx): disambiguate ROCmFP2 GGUF type 107

### DIFF
--- a/.github/workflows/check-rocmfpx.yml
+++ b/.github/workflows/check-rocmfpx.yml
@@ -57,7 +57,6 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: |
           python3 -m py_compile convert_hf_to_gguf.py convert_modular.py conversion/base.py conversion/__init__.py conversion/gemma.py conversion/llama.py scripts/rocmfpx/retag-legacy-rocmfp2.py tools/hyperloom/run_benchmark.py
-          python3 scripts/rocmfpx/retag-legacy-rocmfp2.py --help >/dev/null
           python3 - <<'PY'
           from pathlib import Path
 

--- a/.github/workflows/check-rocmfpx.yml
+++ b/.github/workflows/check-rocmfpx.yml
@@ -40,7 +40,7 @@ jobs:
             git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$HEAD_SHA"
             while IFS= read -r path; do
               case "$path" in
-                ggml/rocmfpx/*|ggml/include/ggml.h|ggml/src/ggml.c|ggml/src/ggml-cuda/*|ggml/src/ggml-vulkan/*|extensions/rocmfpx-vulkan/*|gguf-py/gguf/constants.py|gguf-py/gguf/quants.py|include/rocmfpx-plugin.h|src/llama-quant.cpp|src/llama.cpp|src/llama-model.cpp|src/llama-model.h|src/models/qwen4exp.cpp|src/rocmfpx-plugin.cpp|include/llama.h|tests/rocmfpx-test-plugin.c|tests/test-backend-ops.cpp|tests/test-llama-archs.cpp|tests/test-rocmfpx-plugin.cpp|scripts/check-rocmfpx-*.sh|scripts/check-rocmfp2-*.sh|scripts/check-release-recipe-map.py|scripts/sweep-rocmfpx-*.sh|scripts/build-rocmfpx-*.sh|scripts/rocmfpx/manage-actions-policy.sh|tools/hyperloom/*|docs/recipes/*|.github/workflows/check-rocmfpx.yml)
+                ggml/rocmfpx/*|ggml/include/ggml.h|ggml/src/ggml.c|ggml/src/gguf.cpp|ggml/src/ggml-cpu/*|ggml/src/ggml-cuda/*|ggml/src/ggml-vulkan/*|extensions/rocmfpx-vulkan/*|gguf-py/gguf/constants.py|gguf-py/gguf/quants.py|include/rocmfpx-plugin.h|src/llama-quant.cpp|src/llama.cpp|src/llama-model.cpp|src/llama-model.h|src/llama-model-loader.cpp|src/models/qwen4exp.cpp|src/rocmfpx-plugin.cpp|include/llama.h|tests/rocmfpx-test-plugin.c|tests/test-backend-ops.cpp|tests/test-gguf.cpp|tests/test-llama-archs.cpp|tests/test-rocmfpx-plugin.cpp|scripts/check-rocmfpx-*.sh|scripts/check-rocmfp2-*.sh|scripts/check-release-recipe-map.py|scripts/sweep-rocmfpx-*.sh|scripts/build-rocmfpx-*.sh|scripts/rocmfpx/*|tools/hyperloom/*|docs/recipes/*|.github/workflows/check-rocmfpx.yml)
                   run=true
                   break
                   ;;
@@ -56,7 +56,8 @@ jobs:
       - name: Python converter smoke
         if: steps.scope.outputs.run == 'true'
         run: |
-          python3 -m py_compile convert_hf_to_gguf.py convert_modular.py conversion/base.py conversion/__init__.py conversion/gemma.py conversion/llama.py tools/hyperloom/run_benchmark.py
+          python3 -m py_compile convert_hf_to_gguf.py convert_modular.py conversion/base.py conversion/__init__.py conversion/gemma.py conversion/llama.py scripts/rocmfpx/retag-legacy-rocmfp2.py tools/hyperloom/run_benchmark.py
+          python3 scripts/rocmfpx/retag-legacy-rocmfp2.py --help >/dev/null
           python3 - <<'PY'
           from pathlib import Path
 
@@ -81,7 +82,7 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: |
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_UI=OFF
-          cmake --build build --target test-backend-ops test-rocmfpx-plugin test-llama-archs -j 2
+          cmake --build build --target test-backend-ops test-gguf test-rocmfpx-plugin test-llama-archs -j 2
 
       - name: Reference probe
         if: steps.scope.outputs.run == 'true'
@@ -95,6 +96,10 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: |
           ./build/bin/test-backend-ops test -o MUL_MAT,GET_ROWS,CPY,SET_ROWS -b CPU
+
+      - name: GGUF fail-closed parser
+        if: steps.scope.outputs.run == 'true'
+        run: ctest --test-dir build --output-on-failure -R '^test-gguf$'
 
       - name: Plugin ABI and PLE model fixture
         if: steps.scope.outputs.run == 'true'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,32 @@ The currently qualified formats are experimental. The on-disk layouts of
 ROCmFP2/3/4/6/8 are frozen for compatibility; new kernel and quantizer work
 must preserve their encoded sizes and semantics.
 
+### ROCmFP2 tensor type identity
+
+Canonical dual-scale S40 ROCmFP2 uses GGUF tensor type **111**. Its payload is
+still exactly 10 bytes per 32 weights (2.5 bpw); only the tensor type tag moved.
+Legacy type 107 is reserved as ambiguous because both dual-scale S40 and an
+affine `code * scale - offset` layout were emitted with that same ID and block
+size. ROCmFPX refuses type 107 instead of guessing and silently corrupting a
+model.
+
+New quantizations write type 111 automatically. To audit an older file, run:
+
+```bash
+scripts/rocmfpx/retag-legacy-rocmfp2.py MODEL.gguf
+```
+
+Only when the file's provenance confirms that it uses dual-scale S40, make a
+backup and retag its tensor headers in place:
+
+```bash
+scripts/rocmfpx/retag-legacy-rocmfp2.py MODEL.gguf \
+  --layout s40-dual-scale-v1 --apply
+```
+
+The tool does not inspect or infer the layout because the two interpretations
+cannot be distinguished from the bytes. Do not use it on affine ROCmFP2 files.
+
 ## Optional Charlie Vulkan plugin
 
 The optional [`ROCmFPXVulkan` extension](extensions/rocmfpx-vulkan/README.md)

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -439,11 +439,14 @@ extern "C" {
         GGML_TYPE_Q3_0_ROCMFPX      = 104, // 3-bit UE4M3-scale layout
         GGML_TYPE_TURBO3_0          = 105, // TurboQuant 3-bit KV cache
         GGML_TYPE_TURBO4_0          = 106, // TurboQuant 4-bit KV cache
-        GGML_TYPE_Q2_0_ROCMFPX      = 107, // 2-bit S40 codebook + dual UE4M3 scales
+        // Type 107 was emitted with two incompatible 10-byte ROCmFP2 layouts.
+        // It is retained only so readers can reject ambiguous legacy files.
+        GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS = 107,
         GGML_TYPE_Q4_0_ROCMI4       = 108, // exact signed-nibble 4-bit + UE4M3 scale
         GGML_TYPE_Q5_0_ROCMFPX      = 109, // 5-bit signed linear + dual UE4M3 scales
         GGML_TYPE_Q7_0_ROCMFPX      = 110, // 7-bit signed linear + dual UE4M3 scales
-        GGML_TYPE_COUNT             = 111,
+        GGML_TYPE_Q2_0_ROCMFPX      = 111, // 2-bit S40 codebook + dual UE4M3 scales
+        GGML_TYPE_COUNT             = 112,
     };
 
     // precision

--- a/ggml/rocmfpx/test_rocmfpx.c
+++ b/ggml/rocmfpx/test_rocmfpx.c
@@ -4,6 +4,12 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+
+_Static_assert(GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS == 107,
+        "ambiguous ROCmFP2 legacy type ID changed");
+_Static_assert(GGML_TYPE_Q2_0_ROCMFPX == 111,
+        "canonical dual-scale ROCmFP2 type ID changed");
 
 static void fill_row(float * x, int n) {
     for (int i = 0; i < n; ++i) {
@@ -220,6 +226,32 @@ static void check_fp2_swar_codebook(void) {
     printf("ROCmFP2 Vulkan SWAR: all 256 packed bytes match {-4,-1,1,4}\n");
 }
 
+static void check_fp2_legacy_collision_probe(void) {
+    static const int codebook[4] = {-4, -1, 1, 4};
+    const uint8_t bytes[sizeof(block_rocmfp2)] = {
+        0xe4, 0xe4, 0xe4, 0xe4, 0xe4, 0xe4, 0xe4, 0xe4, 0x38, 0x40,
+    };
+    block_rocmfp2 block;
+    float dual_scale[QK_ROCMFP2];
+    bool layouts_differ = false;
+
+    memcpy(&block, bytes, sizeof(block));
+    rocmfpx_dequantize_row_fp2(&block, dual_scale, QK_ROCMFP2);
+
+    for (int i = 0; i < QK_ROCMFP2; ++i) {
+        const int code = i % 4;
+        const float scale = i < QK_ROCMFP2/2 ? 0.5f : 1.0f;
+        const float expected_dual_scale = (float) codebook[code] * scale;
+        const float expected_affine = (float) code * 0.5f - 1.0f;
+
+        assert(dual_scale[i] == expected_dual_scale);
+        layouts_differ |= expected_dual_scale != expected_affine;
+    }
+
+    assert(layouts_differ);
+    printf("ROCmFP2 type collision probe: identical 10-byte payload has incompatible affine and dual-scale values\n");
+}
+
 int main(void) {
     enum { N = 64 };
 
@@ -307,6 +339,7 @@ int main(void) {
     check_weighted_imatrix_fp8();
     check_weighted_imatrix_i4();
     check_fp2_swar_codebook();
+    check_fp2_legacy_collision_probe();
 
     return 0;
 }

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -1259,6 +1259,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_Q4_0_ROCMFP4:
         case GGML_TYPE_Q4_0_ROCMFP4_FAST:
         case GGML_TYPE_Q4_0_ROCMI4:
+        case GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS:
         case GGML_TYPE_Q2_0_ROCMFPX:
         case GGML_TYPE_Q3_0_ROCMFPX:
         case GGML_TYPE_Q5_0_ROCMFPX:
@@ -5955,6 +5956,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q4_0_ROCMFP4:
         case GGML_TYPE_Q4_0_ROCMFP4_FAST:
         case GGML_TYPE_Q4_0_ROCMI4:
+        case GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS:
         case GGML_TYPE_Q2_0_ROCMFPX:
         case GGML_TYPE_Q3_0_ROCMFPX:
         case GGML_TYPE_Q5_0_ROCMFPX:

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -731,6 +731,12 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) rocmfpx_dequantize_row_fp5,
         .from_float_ref           = (ggml_from_float_t) rocmfpx_quantize_row_fp5_ref,
     },
+    [GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS] = {
+        .type_name                = "q2_0_rocmfpx_legacy_ambiguous",
+        .blck_size                = 0,
+        .type_size                = 0,
+        .is_quantized             = false,
+    },
     [GGML_TYPE_Q2_0_ROCMFPX] = {
         .type_name                = "q2_0_rocmfpx",
         .blck_size                = QK_ROCMFP2,

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -717,6 +717,15 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
                 ok = false;
                 break;
             }
+            if (info.t.type == GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS) {
+                GGML_LOG_ERROR(
+                    "%s: tensor '%s' uses ambiguous legacy ROCmFP2 type 107; "
+                    "the bytes may be affine or dual-scale S40, so refusing to guess. "
+                    "Retag only files with known provenance to a layout-specific type.\n",
+                    __func__, info.t.name);
+                ok = false;
+                break;
+            }
             const size_t  type_size = ggml_type_size(info.t.type);
             const int64_t blck_size = ggml_blck_size(info.t.type);
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -5520,10 +5520,11 @@ class GGMLQuantizationType(IntEnum):
     Q3_0_ROCMFPX      = 104
     TURBO3_0          = 105
     TURBO4_0          = 106
-    Q2_0_ROCMFPX      = 107
+    Q2_0_ROCMFPX_LEGACY_AMBIGUOUS = 107
     Q4_0_ROCMI4       = 108
     Q5_0_ROCMFPX      = 109
     Q7_0_ROCMFPX      = 110
+    Q2_0_ROCMFPX      = 111
 
 
 class ExpertGatingFuncType(IntEnum):
@@ -5747,10 +5748,14 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.Q3_0_ROCMFPX:      (32, 12 + 2),
     GGMLQuantizationType.TURBO3_0:          (32, 12 + 2),
     GGMLQuantizationType.TURBO4_0:          (32, 16 + 2),
-    GGMLQuantizationType.Q2_0_ROCMFPX:      (32, 8 + 2),
+    # Type 107 has two incompatible interpretations. Its size is registered so
+    # migration tools can inspect it, but no quant/dequant implementation may
+    # select a layout automatically.
+    GGMLQuantizationType.Q2_0_ROCMFPX_LEGACY_AMBIGUOUS: (32, 8 + 2),
     GGMLQuantizationType.Q4_0_ROCMI4:       (32, 1 + 16),
     GGMLQuantizationType.Q5_0_ROCMFPX:      (32, 20 + 2),
     GGMLQuantizationType.Q7_0_ROCMFPX:      (32, 28 + 2),
+    GGMLQuantizationType.Q2_0_ROCMFPX:      (32, 8 + 2),
 }
 
 

--- a/scripts/rocmfpx/retag-legacy-rocmfp2.py
+++ b/scripts/rocmfpx/retag-legacy-rocmfp2.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Retag known dual-scale S40 ROCmFP2 tensors from legacy type 107."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "gguf-py"))
+
+import gguf  # noqa: E402
+
+
+LEGACY_TYPE = gguf.GGMLQuantizationType.Q2_0_ROCMFPX_LEGACY_AMBIGUOUS
+S40_TYPE = gguf.GGMLQuantizationType.Q2_0_ROCMFPX
+S40_LAYOUT = "s40-dual-scale-v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit or retag legacy ROCmFP2 GGUF tensor type 107. Type 107 is "
+            "ambiguous, so the tool never attempts to infer the layout from bytes."
+        ),
+    )
+    parser.add_argument("model", type=Path, help="GGUF model or shard to inspect")
+    parser.add_argument(
+        "--layout",
+        choices=(S40_LAYOUT,),
+        help="layout confirmed from model provenance; required with --apply",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="retag matching tensor headers in place (the default is read-only)",
+    )
+    return parser.parse_args()
+
+
+def inspect_model(path: Path, writable: bool) -> tuple[gguf.GGUFReader, list[gguf.ReaderTensor], int]:
+    if not path.is_file():
+        raise ValueError(f"not a regular file: {path}")
+
+    reader = gguf.GGUFReader(path, "r+" if writable else "r")
+    legacy = [tensor for tensor in reader.tensors if tensor.tensor_type == LEGACY_TYPE]
+    canonical_count = sum(tensor.tensor_type == S40_TYPE for tensor in reader.tensors)
+    return reader, legacy, canonical_count
+
+
+def retag(reader: gguf.GGUFReader, tensors: list[gguf.ReaderTensor]) -> None:
+    fields = []
+    for tensor in tensors:
+        raw_type = tensor.field.parts[4]
+        if raw_type.size != 1 or int(raw_type[0]) != int(LEGACY_TYPE):
+            raise RuntimeError(f"tensor type field changed while inspecting {tensor.name}")
+        fields.append(raw_type)
+
+    for raw_type in fields:
+        raw_type[0] = int(S40_TYPE)
+    reader.data.flush()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.apply and args.layout != S40_LAYOUT:
+        raise ValueError(f"--apply requires --layout {S40_LAYOUT}")
+
+    reader, legacy, canonical_count = inspect_model(args.model, args.apply)
+    print(f"model: {args.model}")
+    print(f"legacy ambiguous type 107 tensors: {len(legacy)}")
+    print(f"canonical dual-scale S40 type 111 tensors: {canonical_count}")
+
+    if not legacy:
+        print("no legacy type 107 tensors found; no changes needed")
+        return 0
+
+    for tensor in legacy[:10]:
+        print(f"  {tensor.name}")
+    if len(legacy) > 10:
+        print(f"  ... and {len(legacy) - 10} more")
+
+    if not args.apply:
+        print("read-only audit complete; no bytes changed")
+        print(f"to retag a provenance-confirmed S40 file, add --layout {S40_LAYOUT} --apply")
+        return 0
+
+    legacy_count = len(legacy)
+    retag(reader, legacy)
+    del legacy
+    del reader
+
+    verify_reader, remaining, new_canonical_count = inspect_model(args.model, False)
+    del verify_reader
+    if remaining or new_canonical_count != canonical_count + legacy_count:
+        raise RuntimeError("post-write verification failed")
+
+    print(f"retagged {legacy_count} tensor headers from type 107 to type 111")
+    print("tensor payload bytes and encoded size were not changed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/rocmfpx/validate-sync.sh
+++ b/scripts/rocmfpx/validate-sync.sh
@@ -22,10 +22,11 @@ expected = {
     "Q3_0_ROCMFPX": (104, (32, 14)),
     "TURBO3_0": (105, (32, 14)),
     "TURBO4_0": (106, (32, 18)),
-    "Q2_0_ROCMFPX": (107, (32, 10)),
+    "Q2_0_ROCMFPX_LEGACY_AMBIGUOUS": (107, (32, 10)),
     "Q4_0_ROCMI4": (108, (32, 17)),
     "Q5_0_ROCMFPX": (109, (32, 22)),
     "Q7_0_ROCMFPX": (110, (32, 30)),
+    "Q2_0_ROCMFPX": (111, (32, 10)),
 }
 for name, (value, size) in expected.items():
     qtype = getattr(gguf.GGMLQuantizationType, name)

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -794,6 +794,7 @@ llama_model_loader::llama_model_loader(
             case GGML_TYPE_NVFP4:   ftype = LLAMA_FTYPE_MOSTLY_NVFP4;   break;
             case GGML_TYPE_Q1_0:    ftype = LLAMA_FTYPE_MOSTLY_Q1_0;    break;
             case GGML_TYPE_Q2_0:    ftype = LLAMA_FTYPE_MOSTLY_Q2_0;    break;
+            case GGML_TYPE_Q2_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q2_0_ROCMFPX; break;
             default:
                 {
                     LLAMA_LOG_WARN("%s: unknown type %s\n", __func__, ggml_type_name(type_max));

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -41,6 +41,7 @@ enum handcrafted_file_type {
     HANDCRAFTED_TENSORS_NE_TOO_BIG         =  40 + offset_has_tensors,
     HANDCRAFTED_TENSORS_NBYTES_TOO_BIG     =  45 + offset_has_tensors,
     HANDCRAFTED_TENSORS_BAD_TYPE           =  50 + offset_has_tensors,
+    HANDCRAFTED_TENSORS_LEGACY_Q2_AMBIGUOUS = 55 + offset_has_tensors,
     HANDCRAFTED_TENSORS_BAD_OFFSET         =  60 + offset_has_tensors,
     HANDCRAFTED_TENSORS_DUPLICATE_NAME     =  70 + offset_has_tensors,
     HANDCRAFTED_TENSORS_BAD_ALIGN          =  75 + offset_has_tensors,
@@ -81,6 +82,7 @@ static std::string handcrafted_file_type_name(const enum handcrafted_file_type h
         case HANDCRAFTED_TENSORS_NE_TOO_BIG:         return "TENSORS_NE_TOO_BIG";
         case HANDCRAFTED_TENSORS_NBYTES_TOO_BIG:     return "TENSORS_NBYTES_TOO_BIG";
         case HANDCRAFTED_TENSORS_BAD_TYPE:           return "TENSORS_BAD_TYPE";
+        case HANDCRAFTED_TENSORS_LEGACY_Q2_AMBIGUOUS: return "TENSORS_LEGACY_Q2_AMBIGUOUS";
         case HANDCRAFTED_TENSORS_BAD_OFFSET:         return "TENSORS_BAD_OFFSET";
         case HANDCRAFTED_TENSORS_DUPLICATE_NAME:     return "TENSORS_DUPLICATE_NAME";
         case HANDCRAFTED_TENSORS_BAD_ALIGN:          return "TENSORS_BAD_ALIGN";
@@ -446,7 +448,10 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
         }
 
         {
-            const int32_t type32 = hft == HANDCRAFTED_TENSORS_BAD_TYPE ? GGML_TYPE_COUNT : int32_t(type);
+            const int32_t type32 =
+                hft == HANDCRAFTED_TENSORS_BAD_TYPE ? GGML_TYPE_COUNT :
+                hft == HANDCRAFTED_TENSORS_LEGACY_Q2_AMBIGUOUS ? GGML_TYPE_Q2_0_ROCMFPX_LEGACY_AMBIGUOUS :
+                int32_t(type);
             helper_write(file, type32);
         }
 
@@ -775,6 +780,7 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
         HANDCRAFTED_TENSORS_NE_TOO_BIG,
         HANDCRAFTED_TENSORS_NBYTES_TOO_BIG,
         HANDCRAFTED_TENSORS_BAD_TYPE,
+        HANDCRAFTED_TENSORS_LEGACY_Q2_AMBIGUOUS,
         HANDCRAFTED_TENSORS_BAD_OFFSET,
         HANDCRAFTED_TENSORS_DUPLICATE_NAME,
         HANDCRAFTED_TENSORS_BAD_ALIGN,


### PR DESCRIPTION
## Summary

- reserve GGUF tensor type 107 as an ambiguous legacy ROCmFP2 identity
- move canonical dual-scale S40 ROCmFP2 to type 111 without changing its 10-byte / 32-weight payload
- reject type 107 in the C++ GGUF loader instead of guessing between affine and dual-scale layouts
- add a read-only-by-default, provenance-gated retagging utility for confirmed S40 files
- add collision, loader, Python ID, documentation, and required-CI coverage

## Compatibility and migration

New ROCmFP2 quantizations write type 111 automatically. Existing type-107 files fail closed. A file may be retagged only when its provenance confirms `s40-dual-scale-v1`; affine type-107 files must not be retagged.

## Validation

- ROCmFPX reference probes, including the exact affine-versus-S40 collision block
- ROCmFP2 Phase-1 reference suite: 32,520 checks
- portable `GGML_NATIVE=OFF` required-workflow build
- CPU backend suite: 2,829 / 2,829 operations
- `test-gguf`, quantization, plugin ABI, and Qwen4Exp architecture tests
- focused ROCmFP2 Vulkan and HIP gates: 15 / 15 each
- separate W4A4 HIP gate: 15 / 15
- provenance-confirmed migration test: 196 headers retagged with unchanged file size and payload
- changed-file credential and secret scan

Fixes #8.

Reported by @glovepost.