### PR TITLE
q38rocm migration blockers: --spec-mtp-strict-qwen missing + checkpoint restore needs empty-data_spec tolerance

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3976,6 +3976,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     //
 
     add_opt(common_arg(
+        {"--spec-mtp-strict-qwen"},
+        {"--no-spec-mtp-strict-qwen"},
+        "use boundary-safe verification for exact greedy Qwen35/Qwen35MoE MTP output; requires one slot/sequence (default: disabled)",
+        [](common_params & params, bool value) {
+            params.speculative.mtp_strict_qwen = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_STRICT_QWEN"));
+    add_opt(common_arg(
         {"--spec-draft-hf", "-hfd", "-hfrd", "--hf-repo-draft"}, "<user>/<model>[:quant]",
         "Same as --hf-repo, but for the draft model (default: unused)",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -369,6 +369,7 @@ struct common_params_speculative_ngram_cache {
 
 struct common_params_speculative {
     std::vector<enum common_speculative_type> types = { COMMON_SPECULATIVE_TYPE_NONE };
+    bool mtp_strict_qwen = false;
 
     double synth_len = -1.0;
     std::vector<double> synth_rates;
@@ -396,7 +397,7 @@ struct common_params_speculative {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP || t == COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 || t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
         });
 
-        return needs_rs_seq ? draft.n_max : 0u;
+        return needs_rs_seq ? (uint32_t) std::max<int32_t>(0, draft.n_max) : 0u;
     }
 };
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1758,6 +1758,20 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
         std::memcpy(pending_h[seq_id].data(), verify_h[seq_id].data() + (size_t) i_h * n_embd, row_bytes);
     }
+
+    void set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq || !data.empty()) {
+            return;
+        }
+
+        std::fill(pending_h[seq_id].begin(), pending_h[seq_id].end(), 0.0f);
+        verify_h[seq_id].clear();
+        verify_h_rows[seq_id] = 0;
+        i_last[seq_id] = -1;
+        if (chain_heads) {
+            chain_h[seq_id].clear();
+        }
+    }
 };
 
 // state of self-speculation (simple implementation, not ngram-map)
@@ -2910,6 +2924,8 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id seq_id, u
 
 // TODO: support the case of more than one speculative implementations having a state
 bool common_speculative_get_state(common_speculative * spec, llama_seq_id seq_id, std::vector<uint8_t> & data) {
+    data.clear();
+
     if (spec == nullptr) {
         return false;
     }
@@ -2930,6 +2946,10 @@ void common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id
 
     for (auto & impl : spec->impls) {
         impl->set_state(seq_id, data);
+    }
+
+    if (seq_id >= 0 && seq_id < (llama_seq_id) spec->dparams.size()) {
+        spec->dparams[seq_id].drafting = false;
     }
 }
 

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -255,6 +255,31 @@ static void test(void) {
     assert(params.speculative.draft.n_max == 123);
 
     {
+        common_params strict_params;
+
+        argv = {"binary_name", "--spec-mtp-strict-qwen"};
+        assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_EMBEDDING));
+
+        argv = {"binary_name", "--spec-draft-n-max", "-1"};
+        assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_SPECULATIVE));
+
+        strict_params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_MTP };
+        strict_params.speculative.draft.n_max = 6;
+        assert(strict_params.speculative.need_n_rs_seq() == 6);
+        strict_params.speculative.draft.n_max = -1;
+        assert(strict_params.speculative.need_n_rs_seq() == 0);
+        strict_params.speculative.draft.n_max = 6;
+
+        argv = {"binary_name", "--spec-mtp-strict-qwen"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_SERVER));
+        assert(strict_params.speculative.mtp_strict_qwen);
+
+        argv = {"binary_name", "--no-spec-mtp-strict-qwen"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_SERVER));
+        assert(!strict_params.speculative.mtp_strict_qwen);
+    }
+
+    {
         common_params synth_params;
         argv = {"binary_name", "--spec-synth-len", "3.4"};
         assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), synth_params, LLAMA_EXAMPLE_SERVER));

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -894,6 +894,7 @@ private:
     common_context_seq_rm_type ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
 
     common_speculative_ptr spec;
+    bool strict_qwen_mtp_verification = false;
 
     bool add_bos_token = true;
 
@@ -1117,6 +1118,39 @@ private:
 
         add_bos_token = llama_vocab_get_add_bos(vocab);
 
+        {
+            char model_arch[32] = {};
+            const bool has_model_arch =
+                llama_model_meta_val_str(model_tgt, "general.architecture", model_arch, sizeof(model_arch)) >= 0;
+            const bool is_qwen35 =
+                has_model_arch &&
+                (strcmp(model_arch, "qwen35") == 0 || strcmp(model_arch, "qwen35moe") == 0);
+            const bool has_mtp =
+                std::find(params_base.speculative.types.begin(), params_base.speculative.types.end(),
+                          COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
+
+            strict_qwen_mtp_verification = is_qwen35 && has_mtp && params_base.speculative.mtp_strict_qwen;
+
+            if (params_base.speculative.mtp_strict_qwen && !strict_qwen_mtp_verification) {
+                SRV_ERR("%s", "--spec-mtp-strict-qwen requires a qwen35 or qwen35moe target with draft-mtp enabled\n");
+                return false;
+            }
+
+            if (strict_qwen_mtp_verification) {
+                if (params_base.n_parallel != 1) {
+                    SRV_ERR("%s", "Qwen strict MTP requires one server slot/sequence; restart with -np 1 or use --no-spec-mtp-strict-qwen\n");
+                    return false;
+                }
+                if (llama_n_rs_seq(ctx_tgt) < (uint32_t) params_base.speculative.draft.n_max) {
+                    SRV_ERR("%s", "Qwen strict MTP requires bounded recurrent rollback covering the full draft\n");
+                    return false;
+                }
+                SRV_WRN("%s", "Qwen strict MTP: boundary-safe verification with bounded recurrent rollback is enabled for exact greedy output\n");
+            } else if (is_qwen35 && has_mtp) {
+                SRV_WRN("%s", "Qwen MTP strict verification is disabled; greedy output may diverge from no-spec decoding (enable --spec-mtp-strict-qwen)\n");
+            }
+        }
+
         if (has_spec) {
             // spec_mtp doesn't use load a model internally, so we report 0.0 and 1.0 manually
             load_progress_callback(0.0f, &load_progress_spec);
@@ -1238,6 +1272,12 @@ private:
         slots.clear();
 
         ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
+        if (strict_qwen_mtp_verification &&
+            (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
+             llama_n_rs_seq(ctx_tgt) < (uint32_t) params_base.speculative.draft.n_max)) {
+            SRV_ERR("%s", "Qwen strict MTP requires bounded rollback covering the full draft\n");
+            return false;
+        }
         if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             SRV_WRN("%s", "speculative decoding not supported by this context\n");
         }
@@ -2974,7 +3014,19 @@ private:
                 const bool use_ckpt_tgt = ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
                 const bool use_ckpt_dft = ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
 
-                const int n_draft_max = slot.get_n_draft_max();
+                int n_draft_max = slot.get_n_draft_max();
+
+                if (strict_qwen_mtp_verification) {
+                    // Keep verification within one padded KV block to match serial reduction widths.
+                    if (slot.truncated || slot.prompt.tokens.pos_next() < 0) {
+                        n_draft_max = 0;
+                    } else {
+                        constexpr uint32_t kv_pad = 256;
+                        const uint32_t rows_to_boundary =
+                            kv_pad - ((uint32_t) slot.prompt.tokens.pos_next() % kv_pad);
+                        n_draft_max = std::min(n_draft_max, std::max(0, (int) rows_to_boundary - 1));
+                    }
+                }
 
                 if (n_draft_max > 0) {
                     GGML_ASSERT(slot.can_speculate());
@@ -3374,9 +3426,21 @@ private:
 
                         // [TAG_PROMPT_LOGITS]
                         if (n_past == slot.task->n_tokens() && n_past > 0) {
-                            SLT_WRN(slot, "need to evaluate at least 1 token for each active slot (n_past = %d, task.n_tokens() = %d)\n", n_past, slot.task->n_tokens());
-                            n_past--;
-                            SLT_WRN(slot, "n_past was set to %d\n", n_past);
+                            if (strict_qwen_mtp_verification) {
+                                // An exact recurrent cache hit lacks rollback history, so rebuild the prompt and MTP boundary state.
+                                SLT_WRN(slot,
+                                        "prompt cache cold fallback: reason=strict-qwen-exact-hit cached_tokens=%d request_tokens=%d\n",
+                                        n_past, slot.task->n_tokens());
+                                n_past = 0;
+                                slot.spec_draft.clear();
+                                slot.spec_i_batch.clear();
+                                slot.spec_ckpt.clear();
+                                common_speculative_set_state(spec.get(), slot.id, {});
+                            } else {
+                                SLT_WRN(slot, "need to evaluate at least 1 token for each active slot (n_past = %d, task.n_tokens() = %d)\n", n_past, slot.task->n_tokens());
+                                n_past--;
+                                SLT_WRN(slot, "n_past was set to %d\n", n_past);
+                            }
                         }
 
                         slot.stats.n_prompt_cached    = n_past;


### PR DESCRIPTION
## Overview

Ports the strict Qwen MTP verification mode and tolerates empty speculative checkpoint state during restore.

Closes #10.

## Additional information

Julian Beltran is the Git author of the checkpoint-state commit adapted from julianmb/q38rocm. Local qualification covered CPU and Strix builds, recurrent state restoration tests, the ROCmFPX reference check, and deterministic ROCm0 MTP/cache runtime comparisons.

## Requirements

- I have read and agree with the contributing guidelines.
- AI usage disclosure: YES - OpenAI Codex assisted with adaptation, testing, and delivery. The repository owner is responsible for the submitted changes.