### PR TITLE
chore: assign downstream code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -120,3 +120,7 @@
 /build-xcframework.sh                   @danbev
 requirements*.txt                       @CISC
 /skills                                 @ngxson
+
+# ROCmFPX downstream ownership. Keep this final catch-all last so the local
+# maintainers take precedence over inherited upstream ownership mappings.
+*                                       @ROCmFPX @charlie12345


### PR DESCRIPTION
## Summary

- Preserve the inherited upstream ownership mappings as reference.
- Add a final downstream catch-all for @ROCmFPX and @charlie12345.
- Make required code-owner reviews satisfiable by maintainers with access to this repository.

## Validation

- git diff --check
- Verified @ROCmFPX has admin access and @charlie12345 has write access.

## AI assistance

Codex prepared and validated this one-file policy change under the repository owner-authorized automation policy.