### PR TITLE
server: allow strict Qwen MTP for qwen4exp after vanilla rollback

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3988,7 +3988,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     add_opt(common_arg(
         {"--spec-mtp-strict-qwen"},
         {"--no-spec-mtp-strict-qwen"},
-        "use boundary-safe verification for exact greedy Qwen35/Qwen35MoE MTP output; requires one slot/sequence (default: disabled)",
+        "use boundary-safe verification for exact greedy Qwen35/Qwen35MoE/Qwen4Exp MTP output; requires one slot/sequence (default: disabled)",
         [](common_params & params, bool value) {
             params.speculative.mtp_strict_qwen = value;
         }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1122,17 +1122,18 @@ private:
             char model_arch[32] = {};
             const bool has_model_arch =
                 llama_model_meta_val_str(model_tgt, "general.architecture", model_arch, sizeof(model_arch)) >= 0;
-            const bool is_qwen35 =
+            const bool is_strict_qwen_arch =
                 has_model_arch &&
-                (strcmp(model_arch, "qwen35") == 0 || strcmp(model_arch, "qwen35moe") == 0);
+                (strcmp(model_arch, "qwen35") == 0 || strcmp(model_arch, "qwen35moe") == 0 ||
+                 strcmp(model_arch, "qwen4exp") == 0);
             const bool has_mtp =
                 std::find(params_base.speculative.types.begin(), params_base.speculative.types.end(),
                           COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
 
-            strict_qwen_mtp_verification = is_qwen35 && has_mtp && params_base.speculative.mtp_strict_qwen;
+            strict_qwen_mtp_verification = is_strict_qwen_arch && has_mtp && params_base.speculative.mtp_strict_qwen;
 
             if (params_base.speculative.mtp_strict_qwen && !strict_qwen_mtp_verification) {
-                SRV_ERR("%s", "--spec-mtp-strict-qwen requires a qwen35 or qwen35moe target with draft-mtp enabled\n");
+                SRV_ERR("%s", "--spec-mtp-strict-qwen requires a qwen35, qwen35moe, or qwen4exp target with draft-mtp enabled\n");
                 return false;
             }
 
@@ -1146,7 +1147,7 @@ private:
                     return false;
                 }
                 SRV_WRN("%s", "Qwen strict MTP: boundary-safe verification with bounded recurrent rollback is enabled for exact greedy output\n");
-            } else if (is_qwen35 && has_mtp) {
+            } else if (is_strict_qwen_arch && has_mtp) {
                 SRV_WRN("%s", "Qwen MTP strict verification is disabled; greedy output may diverge from no-spec decoding (enable --spec-mtp-strict-qwen)\n");
             }
         }


### PR DESCRIPTION
## Overview

Adapt the useful qwen4exp allowlist portion of Julian Beltran's PR #12 onto the vanilla qwen4exp recurrent-rollback implementation now present on `main`.

The authored commit retains `Julian Beltran <julianmb@gmail.com>` and the original author date. It adds qwen4exp to the strict-Qwen server gate, updates the error and CLI help text, and deliberately keeps both bounded rollback checks intact. It does not include the original rollback bypass or the incorrect claim that qwen4exp has no recurrent state.

## Additional information

Validation on Strix Halo / gfx1151:

- HIP + Vulkan server and `test-arg-parser` build: passed
- `test-arg-parser`: passed
- CLI help lists Qwen4Exp: passed
- Vanilla-only A/B control rejects the qwen4exp fixture at the strict-Qwen allowlist
- Corrected build passes the allowlist and reports bounded recurrent rollback enabled
- The tiny synthetic fixture then stops at MTP-context creation only because it intentionally contains no MTP layers
- Vanilla qwen4exp recurrent rollback already passed exact split replay on CPU, Vulkan, and HIP
- Vanilla post-merge reference workflow passed on `main`

Original contribution: #12 at `334f10d81311c27f27f136c3e2d01676022462b5`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex reviewed the original PR against vanilla rollback support, prepared the minimal corrected adaptation, ran the build/runtime qualification, and drafted this downstream PR under the owner-authorized automation policy. The repository owner is responsible for the submitted changes.