### PR TITLE
vulkan: fix split-K reduction flags in the default backend

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2088,7 +2088,9 @@ struct vk_op_flash_attn_split_k_reduce_push_constants {
     uint32_t ne3;
     uint32_t k_num;
     uint32_t sinks;
+    uint32_t flags;
 };
+static_assert(sizeof(vk_op_flash_attn_split_k_reduce_push_constants) == 7 * sizeof(uint32_t));
 
 struct vk_op_flash_attn_mask_opt_push_constants {
     uint32_t nem0;
@@ -11433,7 +11435,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                                     pc, { dispatch_x, workgroups_y, workgroups_z });
 
         ggml_vk_sync_buffers(ctx, subctx);
-        const vk_op_flash_attn_split_k_reduce_push_constants pc2 = { HSV, (uint32_t)ne1, (uint32_t)ne2, (uint32_t)ne3, split_k, (sinks != nullptr) };
+        const vk_op_flash_attn_split_k_reduce_push_constants pc2 = { HSV, (uint32_t)ne1, (uint32_t)ne2, (uint32_t)ne3, split_k, (sinks != nullptr), 0 };
         ggml_vk_dispatch_pipeline(ctx, subctx, ctx->device->pipeline_flash_attn_split_k_reduce,
                                     {split_k_buf, sinks_buf, dst_buf},
                                     pc2, { (uint32_t)ne1, HSV, (uint32_t)(ne2 * ne3) });

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10289,6 +10289,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 1024,   1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 1, 2, 3}, true, true));
     test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 1024,  64, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 1, 2, 3}, true, true));
 
+    // Qwen4Exp: short GQA batches use the Vulkan split-K reduction shader.
+    for (int nb : {1, 4, 21}) {
+        test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {12, 1}, 256, nb, true, false, 0, 0,
+            GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    }
+
     // Sparse mask hint: supported decode/prefill layouts and dense fallbacks.
     test_cases.emplace_back(new test_flash_attn_ext(512, 512, 1, { 8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, false,  512));
     test_cases.emplace_back(new test_flash_attn_ext(512, 512, 1, { 8, 2}, 4096, 3, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, false,  768));


### PR DESCRIPTION
## Overview

Fix default Vulkan Flash Attention split-K corruption with ordinary F16 KV caches. The host supplied six push-constant words while the shared shader expected seven. The undefined last word could enable the TurboQuant inverse V transform on non-TurboQuant data.

Add and initialize the missing `flags` field, assert the matching structure size, and add three short-batch GQA cases to the existing backend evaluation suite. The Charlie backend already supplies this field and is unchanged. Original TurboQuant work by @PlunderStruck remains in the existing commit ancestry.

## Validation

- Fresh Vulkan Release build directly on public main `22496778eed64a04fe9b3c7aeba72656da7b513d`.
- Radeon 8060S / RADV: 3/3 targeted short-batch attention cases; 9/9 expanded attention cases.
- GGUF and plugin tests: 2/2 passed.
- Qwen4Exp architecture fixture: CPU and Vulkan comparison/roundtrip passed (Vulkan NMSE 8.51e-08).
- ROCmFPX and ROCmFP2 reference probes and released-model recipe map passed.
- Separately, the identical Vulkan patch in a local PLE/MTP integration repairs a previously failing real Qwen3.8 Flash Next chat at partial and full GPU offload. This PR does not include that model integration or claim complete MTP greedy-equivalence qualification.

This PR is only the small Vulkan repair. No HIP code, Charlie backend, service launchers, or protected-main settings are changed. Other GPU vendors have not been tested locally.

## Requirements

- Submitted to the owner-authorized ROCmFPX downstream only; human owner review and required checks remain mandatory before merging.
- AI usage disclosure: YES. Codex diagnosed the mismatch, implemented the patch and regression cases, and ran the reported local validation. The owner remains responsible for review and maintenance.
