### PR TITLE
rocmfpx: restore RDNA3 HIP MMQ selection and loader classification

### DIFF
--- a/ggml/rocmfpx/rocmfpx_mmq_rdna3.cuh
+++ b/ggml/rocmfpx/rocmfpx_mmq_rdna3.cuh
@@ -1,0 +1,30 @@
+#pragma once
+
+// ROCmFPX tile loaders use Q8_0 staging, with Q3_K-sized scale storage for dual-scale formats.
+static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_rocmfpx_mmq_get_config_rdna3(
+        ggml_type type, int J, bool fallback) {
+    auto layout = GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0;
+    bool supported = true;
+    switch (type) {
+        case GGML_TYPE_Q4_0_ROCMFP4_FAST:
+        case GGML_TYPE_Q4_0_ROCMI4:
+        case GGML_TYPE_Q8_0_ROCMFPX:
+            break;
+        case GGML_TYPE_Q4_0_ROCMFP4:
+        case GGML_TYPE_Q2_0_ROCMFPX:
+        case GGML_TYPE_Q3_0_ROCMFPX:
+        case GGML_TYPE_Q6_0_ROCMFPX:
+            layout = GGML_CUDA_MMQ_SRAM_LAYOUT_Q3_K;
+            break;
+        default:
+            supported = false;
+            break;
+    }
+
+    // Four WMMA warps cover 64 rows. These tiles stay below the RDNA3 64 KiB LDS limit.
+    if (supported && J >= 16 && J <= 128 && J % 16 == 0) {
+        return ggml_cuda_mmq_config(type, 128, 2, 64, J, layout, MMQ_ITER_K, false, fallback);
+    }
+
+    return ggml_cuda_mmq_config(GGML_TYPE_COUNT, 256, 2, 128, 64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0, 256, false, true);
+}

--- a/ggml/rocmfpx/test_rocmfpx_mmq.cpp
+++ b/ggml/rocmfpx/test_rocmfpx_mmq.cpp
@@ -1,0 +1,82 @@
+#include "ggml.h"
+#define GGML_COMMON_DECL_CPP
+#define GGML_COMMON_DECL_HIP
+#include "ggml-common.h"
+
+#include <cstdio>
+#include <initializer_list>
+#include <tuple>
+
+// Compile the real configuration declarations and tables without a GPU runtime.
+#define __host__
+#define __device__
+#define AMD_WMMA_AVAILABLE
+#define GGML_ROCMI4_W4A4 0
+#define MMQ_TILE_NE_K 32
+#define MMQ_ITER_K 256
+#define MMQ_ITER_K_FP4 512
+static bool amd_mfma_available(int) { return false; }
+static bool amd_wmma_available(int) { return true; }
+static bool turing_mma_available(int) { return false; }
+#include "rocmfpx-mmq-config-extract.h"
+
+// Disable only the downstream fallback to obtain the vanilla table as a control.
+#define ggml_cuda_mmq_get_config_rdna3 ggml_cuda_mmq_get_config_rdna3_vanilla
+#define ggml_rocmfpx_mmq_get_config_rdna3(type, J, fallback) \
+    ggml_cuda_mmq_config(GGML_TYPE_COUNT, 256, 2, 128, 64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0, 256, false, true)
+#define CASE(type_, nt_, occ_, I_, J_, layout_, K_, stream_, fallback_) \
+    if (type == type_ && J == J_ && fallback == fallback_) { \
+        return ggml_cuda_mmq_config(type_, nt_, occ_, I_, J_, layout_, K_, stream_, fallback_); \
+    }
+#include "mmq-config-rdna3.cuh"
+#undef CASE
+#undef ggml_rocmfpx_mmq_get_config_rdna3
+#undef ggml_cuda_mmq_get_config_rdna3
+
+static bool equal(const ggml_cuda_mmq_config & a, const ggml_cuda_mmq_config & b) {
+    return std::tie(a.type, a.nthreads, a.occupancy, a.I, a.J, a.sram_layout, a.K_vram, a.stream_k, a.fallback) ==
+           std::tie(b.type, b.nthreads, b.occupancy, b.I, b.J, b.sram_layout, b.K_vram, b.stream_k, b.fallback);
+}
+
+static bool custom(ggml_type type) {
+    return type == GGML_TYPE_Q4_0_ROCMFP4 || type == GGML_TYPE_Q4_0_ROCMFP4_FAST ||
+           type == GGML_TYPE_Q4_0_ROCMI4 || type == GGML_TYPE_Q2_0_ROCMFPX ||
+           type == GGML_TYPE_Q3_0_ROCMFPX || type == GGML_TYPE_Q6_0_ROCMFPX || type == GGML_TYPE_Q8_0_ROCMFPX;
+}
+
+int main() {
+    int controls = 0;
+    int configs = 0;
+    for (int t = 0; t < GGML_TYPE_COUNT; ++t) {
+        const auto type = static_cast<ggml_type>(t);
+        for (bool fallback : {false, true}) {
+            for (int J = 0; J <= 136; J += 8) {
+                const auto got = ggml_cuda_mmq_get_config_rdna3(type, J, fallback);
+                const auto ref = ggml_cuda_mmq_get_config_rdna3_vanilla(type, J, fallback);
+                if (!custom(type) || J < 16 || J > 128 || J % 16 != 0) {
+                    if (!equal(got, ref)) {
+                        std::fprintf(stderr, "FAIL vanilla control: type=%d J=%d fallback=%d\n", t, J, fallback);
+                        return 1;
+                    }
+                    ++controls;
+                    continue;
+                }
+                const bool dual_scale = type == GGML_TYPE_Q4_0_ROCMFP4 || type == GGML_TYPE_Q2_0_ROCMFPX ||
+                                        type == GGML_TYPE_Q3_0_ROCMFPX || type == GGML_TYPE_Q6_0_ROCMFPX;
+                const auto layout = dual_scale ? GGML_CUDA_MMQ_SRAM_LAYOUT_Q3_K : GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0;
+                const auto expected = ggml_cuda_mmq_config(type, 128, 2, 64, J, layout, MMQ_ITER_K, false, fallback);
+                // Match the RDNA3 MMA allocation: X tile + Q8_1 Y tile + row IDs.
+                const int y_bytes = J * (128 + 16);
+                const int alignment = got.nthreads * 4;
+                const int lds = got.I * ggml_cuda_mmq_get_sram_stride(got.sram_layout) * 4 +
+                                (y_bytes + alignment - 1) / alignment * alignment + J * 4;
+                if (!equal(got, expected) || lds > 65536 || got.nthreads / 32 * got.rows_per_warp() != got.I) {
+                    std::fprintf(stderr, "FAIL ROCmFPX configuration: type=%d J=%d fallback=%d LDS=%d\n", t, J, fallback, lds);
+                    return 1;
+                }
+                ++configs;
+            }
+        }
+    }
+    std::printf("PASS RDNA3 MMQ: %d ROCmFPX configurations, %d unchanged vanilla/unsupported controls\n", configs, controls);
+}

--- a/ggml/src/ggml-cuda/mmq-config-rdna3.cuh
+++ b/ggml/src/ggml-cuda/mmq-config-rdna3.cuh
@@ -1,3 +1,5 @@
+#include "../../rocmfpx/rocmfpx_mmq_rdna3.cuh"
+
 static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_cuda_mmq_get_config_rdna3(ggml_type type, int J, bool fallback) {
     CASE(GGML_TYPE_Q1_0, 128, 2,  64,  16, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q1_0, 128, 2,  64,  32, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0, MMQ_ITER_K, false, true);
@@ -270,5 +272,5 @@ static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_cuda_mmq_get_conf
     CASE(GGML_TYPE_NVFP4, 256, 2, 128,  96, GGML_CUDA_MMQ_SRAM_LAYOUT_NVFP4, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_NVFP4, 256, 2, 128, 128, GGML_CUDA_MMQ_SRAM_LAYOUT_NVFP4, MMQ_ITER_K, false, false);
 
-    return ggml_cuda_mmq_config(GGML_TYPE_COUNT, 256, 2, 128, 64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_0, 256, false, true);
+    return ggml_rocmfpx_mmq_get_config_rdna3(type, J, fallback);
 }

--- a/scripts/check-rocmfpx-reference.sh
+++ b/scripts/check-rocmfpx-reference.sh
@@ -21,3 +21,11 @@ mkdir -p "$BUILD_DIR"
     -o "$BUILD_DIR/test-rocmfpx"
 
 "$BUILD_DIR/test-rocmfpx"
+
+# Exercise the real HIP selector tables on CPU-only CI workers.
+sed -n '/^enum ggml_cuda_mmq_sram_layout {/,/^#undef CASE/p' \
+    "$ROOT/ggml/src/ggml-cuda/mmq.cuh" > "$BUILD_DIR/rocmfpx-mmq-config-extract.h"
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror \
+    -I"$ROOT/ggml/include" -I"$ROOT/ggml/src" -I"$ROOT/ggml/src/ggml-cuda" -I"$BUILD_DIR" \
+    "$ROOT/ggml/rocmfpx/test_rocmfpx_mmq.cpp" -o "$BUILD_DIR/test-rocmfpx-mmq"
+"$BUILD_DIR/test-rocmfpx-mmq"

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -795,6 +795,14 @@ llama_model_loader::llama_model_loader(
             case GGML_TYPE_Q1_0:    ftype = LLAMA_FTYPE_MOSTLY_Q1_0;    break;
             case GGML_TYPE_Q2_0:    ftype = LLAMA_FTYPE_MOSTLY_Q2_0;    break;
             case GGML_TYPE_Q2_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q2_0_ROCMFPX; break;
+            case GGML_TYPE_Q4_0_ROCMFP4: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_ROCMFP4; break;
+            case GGML_TYPE_Q4_0_ROCMFP4_FAST: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_ROCMFP4_FAST; break;
+            case GGML_TYPE_Q4_0_ROCMI4: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_ROCMI4; break;
+            case GGML_TYPE_Q3_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q3_0_ROCMFPX; break;
+            case GGML_TYPE_Q5_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q5_0_ROCMFPX; break;
+            case GGML_TYPE_Q6_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q6_0_ROCMFPX; break;
+            case GGML_TYPE_Q7_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q7_0_ROCMFPX; break;
+            case GGML_TYPE_Q8_0_ROCMFPX: ftype = LLAMA_FTYPE_MOSTLY_Q8_0_ROCMFPX; break;
             default:
                 {
                     LLAMA_LOG_WARN("%s: unknown type %s\n", __func__, ggml_type_name(type_max));


### PR DESCRIPTION
## Overview

Refs #17. Restore the missing ROCmFPX HIP MMQ configurations on RDNA3 and the missing loader format-summary cases.

The missing RDNA3 configurations explain the reported `J_best=0` abort. The loader's `unknown type` warning comes from format classification; it does not establish that tensor bytes were decoded as F32. The reporter's CPU corruption remains unconfirmed with their exact model.

- Add a ROCmFPX-only fallback using existing tile loaders. Leave vanilla RDNA3 entries unchanged.
- Restore format labels without changing quantization math, GGUF type IDs, Vulkan, or MTP.
- Add a host selector regression to the existing reference gate.

This is a small adaptation of the ROCmFPX implementation in `charlie12345/ROCmFPX@c49ebdbd5c9f01ec242369f9e7f7967855f80cba`, not a wholesale import of the older HIP backend. Source credit is recorded in the commit.

## Validation

Tested head: `9b443bb2ad185df6db020c2a36e25ebe4dd361eb`, based on public main `7cc672bf5ebc74e50892c1f28acaf122a67339f4`.

- Host selector regression: fails before the fallback is connected; passes 112 custom configurations and 3,920 unchanged vanilla/unsupported controls afterward. GCC and Clang tested; checks include LDS bounds and WMMA row coverage.
- Existing ROCmFPX and ROCmFP2 references pass; CPU operator suite 2,909/2,909; GGUF/plugin tests 2/2.
- HIP 7 / Clang 21.1.8 build succeeds for both gfx1100 and gfx1151.
- On gfx1151: 541/541 supported HIP operator cases pass against CPU. Existing unsupported cases are skipped.
- Fresh BF16-to-ROCmFP4 FAST, ROCmFP6, and Q8_0 conversions of Qwen3-0.6B produce the same short arithmetic answer on CPU and HIP, with correct HIP loader labels and no kernel abort. This is a smoke test, not a general model-quality evaluation.
- Qwen4Exp MoE fixture passes on CPU and HIP, including serialization roundtrip; HIP NMSE versus CPU is `9.80e-14`.
- Separate local audit merge with vanilla llama.cpp `427291b5b34cd914a31b3fd3b61a68f6184f4b9f` is conflict-free, builds, and passes 2,944 CPU operator tests, GGUF/plugin tests, and the Qwen4Exp fixture. That audit merge is not included in this PR. Future upstream merges still require qualification.

## Required before leaving draft

- [ ] Validate the actual RX 7900 XTX/gfx1100 hardware, first one GPU and then the reporter's two-GPU setup, using ROCmFP4 FAST and ROCmFP6 with Q8_0 controls.
- [ ] Recheck the reporter's exact model/source, conversion command, build SHA, CPU output, and HIP output; do not treat the separate CPU report as resolved solely by this patch.
- [ ] Required owner review and GitHub checks on the final head.

No production service, launcher, main branch, or protection setting was changed. Keep this PR unmerged and issue #17 open until the hardware results are available.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) (owner confirmation remains pending).
- AI usage disclosure: YES. Codex assisted with diagnosis, implementation, local testing, commit text, and this description under the owner-authorized ROCmFPX downstream automation policy. The owner authorized draft publication; this does not claim a completed human code review. The owner remains responsible for reviewing and maintaining the submitted code.
