### PR TITLE
qwen4exp: add split PLE and native MTP support with upstream compatibility checks

### DIFF
--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -706,6 +706,7 @@ class MODEL_TENSOR(IntEnum):
     LAYER_OUT_NORM       = auto()
     LAYER_OUT_SCALE      = auto()
     PER_LAYER_TOKEN_EMBD = auto() # gemma3n
+    PLE_NGRAM_EMBD       = auto() # qwen4exp, one tensor per n-gram head
     PER_LAYER_MODEL_PROJ = auto() # gemma3n
     PER_LAYER_INP_GATE   = auto() # gemma3n
     PER_LAYER_PROJ       = auto() # gemma3n
@@ -1457,6 +1458,7 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.LAYER_OUT_NORM:            "blk.{bid}.layer_output_norm",
     MODEL_TENSOR.LAYER_OUT_SCALE:           "blk.{bid}.layer_output_scale",
     MODEL_TENSOR.PER_LAYER_TOKEN_EMBD:      "per_layer_token_embd",           # gemma3n
+    MODEL_TENSOR.PLE_NGRAM_EMBD:            "ple_ngram_embd.{bid}",           # qwen4exp
     MODEL_TENSOR.PER_LAYER_MODEL_PROJ:      "per_layer_model_proj",           # gemma3n
     MODEL_TENSOR.PER_LAYER_PROJ_NORM:       "per_layer_proj_norm",            # gemma3n
     MODEL_TENSOR.ALTUP_UNEMBD_PROJ:         "altup_unembd_proj",              # gemma3n
@@ -2919,6 +2921,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE_EXP,
         MODEL_TENSOR.FFN_GATE_UP_EXP,
         MODEL_TENSOR.PER_LAYER_TOKEN_EMBD,
+        MODEL_TENSOR.PLE_NGRAM_EMBD,
         MODEL_TENSOR.PLE_KEY,
         MODEL_TENSOR.PLE_VALUE,
         MODEL_TENSOR.PLE_NORM_KEY,

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -547,6 +547,7 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
     { LLM_TENSOR_ATTN_COMPRESSOR_APE,                    "blk.%d.attn_compressor_ape" },
     { LLM_TENSOR_ATTN_COMPRESSOR_NORM,                   "blk.%d.attn_compressor_norm" },
     { LLM_TENSOR_PER_LAYER_TOKEN_EMBD,                   "per_layer_token_embd" },
+    { LLM_TENSOR_PLE_NGRAM_EMBD,                         "ple_ngram_embd.%d" },
     { LLM_TENSOR_PER_LAYER_MODEL_PROJ,                   "per_layer_model_proj" },
     { LLM_TENSOR_PER_LAYER_PROJ_NORM,                    "per_layer_proj_norm" },
     { LLM_TENSOR_ALTUP_UNEMBD_PROJ,                      "altup_unembd_proj" },
@@ -900,6 +901,7 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
     {LLM_TENSOR_FFN_EXP_PROBS_B_VL,         {LLM_TENSOR_LAYER_REPEATING, GGML_OP_ADD}},
     // altup / laurel (gemma 3n)
     {LLM_TENSOR_PER_LAYER_TOKEN_EMBD,       {LLM_TENSOR_LAYER_INPUT,     GGML_OP_GET_ROWS}},
+    {LLM_TENSOR_PLE_NGRAM_EMBD,             {LLM_TENSOR_LAYER_REPEATING, GGML_OP_GET_ROWS}},
     {LLM_TENSOR_PER_LAYER_MODEL_PROJ,       {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_PER_LAYER_PROJ_NORM,        {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL}},
     {LLM_TENSOR_ALTUP_PROJ,                 {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL_MAT}},

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1009,7 +1009,9 @@ std::string LLM_TN_IMPL::str() const {
         GGML_ABORT("unknown tensor name for tensor id %d", static_cast<int>(tensor));
     }
 
-    std::string name = ::format(LLM_TENSOR_NAMES.at(tensor), bid, xid);
+    // Split PLE tables use a head index in the name and a layer index for placement.
+    const int name_index = tensor == LLM_TENSOR_PLE_NGRAM_EMBD ? xid : bid;
+    std::string name = ::format(LLM_TENSOR_NAMES.at(tensor), name_index, xid);
     if (suffix != nullptr) {
         name += ".";
         name += suffix;

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -487,6 +487,7 @@ enum llm_tensor {
     LLM_TENSOR_POST_ATTN_NORM,
     LLM_TENSOR_POST_MLP_NORM,
     LLM_TENSOR_PER_LAYER_TOKEN_EMBD, // gemma3n
+    LLM_TENSOR_PLE_NGRAM_EMBD,       // qwen4exp, one tensor per n-gram head
     LLM_TENSOR_PER_LAYER_MODEL_PROJ, // gemma3n
     LLM_TENSOR_PER_LAYER_INP_GATE,   // gemma3n
     LLM_TENSOR_PER_LAYER_PROJ,       // gemma3n

--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -476,6 +476,9 @@ void llama_model_saver::add_tensors_from_model() {
     add_tensor(model->hc_head_base);
     add_tensor(model->hc_head_scale);
     add_tensor(model->per_layer_tok_embd);
+    for (const ggml_tensor * tensor : model->ple_ngram_embd) {
+        add_tensor(tensor);
+    }
     add_tensor(model->hc_head_norm);
     add_tensor(model->hc_head_down);
     add_tensor(model->hc_head_up);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2438,7 +2438,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                 const bool mtp_on_hybrid_qwen =
                     params.ctx_type == LLAMA_CONTEXT_TYPE_MTP &&
                     (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_QWEN35 || arch == LLM_ARCH_QWEN35MOE ||
-                     arch == LLM_ARCH_BAILINGMOE3);
+                     arch == LLM_ARCH_QWEN4EXP || arch == LLM_ARCH_BAILINGMOE3);
 
                 const bool mtp_on_hybrid_nemotron =
                     params.ctx_type == LLAMA_CONTEXT_TYPE_MTP && arch == LLM_ARCH_NEMOTRON_H_MOE;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -658,6 +658,7 @@ struct llama_model {
     struct ggml_tensor * altup_proj           = nullptr;
     struct ggml_tensor * altup_unembd_proj    = nullptr;
     struct ggml_tensor * per_layer_tok_embd   = nullptr;
+    std::vector<ggml_tensor *> ple_ngram_embd;
 
     struct ggml_tensor * hc_head_norm = nullptr;
     struct ggml_tensor * hc_head_down = nullptr;

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -2285,7 +2285,10 @@ struct llama_model_qwen4exp : public llama_model_base {
 
     struct graph : public llm_build_delta_net_base {
         graph(const llama_model & model, const llm_graph_params & params);
-    private:
+    protected:
+        // Members only, no trunk: graph_mtp builds its own single block.
+        graph(const llama_model & model, const llm_graph_params & params, bool mtp);
+
         // HC replaces every layer norm: residual is [n_embd, hc, n_tokens]
         ggml_tensor * build_hc_mix(
                     ggml_tensor * x,
@@ -2375,6 +2378,10 @@ struct llama_model_qwen4exp : public llama_model_base {
                             int   il);
 
         const llama_model & model;
+    };
+
+    struct graph_mtp : public graph {
+        graph_mtp(const llama_model & model, const llm_graph_params & params);
     };
 
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -296,6 +296,10 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
 
     // The MTP draft block sits one past the trunk. It is a full qwen4exp layer plus the
     // three nextn tensors, and is skipped unless the file is opened as a draft.
+    std::array<uint32_t, LLAMA_MAX_LAYERS> mtp_ff_exp = {};
+    if (hparams.n_layer_nextn > 0) {
+        ml.get_key_or_arr(LLM_KV_EXPERT_FEED_FORWARD_LENGTH, mtp_ff_exp, hparams.n_layer_all, false);
+    }
     for (int il = n_layer; il < n_layer + (int) hparams.n_layer_nextn; ++il) {
         if (ml.files.empty() && !ml.load_mtp) {
             continue;
@@ -303,7 +307,7 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
         auto & layer = layers[il];
 
         const int flags = ml.load_mtp ? 0 : TENSOR_SKIP | TENSOR_SKIP_IF_VIRTUAL;
-        const int64_t n_ff_exp   = hparams.n_ff_exp   ? hparams.n_ff_exp   : n_ff / n_expert_used;
+        const int64_t n_ff_exp   = mtp_ff_exp[il] ? mtp_ff_exp[il] : n_ff / n_expert_used;
         const int64_t n_ff_shexp = hparams.n_ff_shexp ? hparams.n_ff_shexp : n_ff;
         const int64_t idx_dim    = hparams.indexer_head_size;
 

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -53,6 +53,7 @@ void llama_model_qwen4exp::load_arch_hparams(llama_model_loader & ml) {
     qwen4exp_require_nonzero(ml, LLM_KV_HYPER_CONNECTION_LOW_RANK, hparams.hc_low_rank);
     hparams.n_embd_out_impl = hparams.dsv4_hc_mult * hparams.n_embd;
 
+    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
     ml.get_key(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT, hparams.indexer_n_head);
     ml.get_key(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH, hparams.indexer_head_size);
     ml.get_key(LLM_KV_ATTENTION_INDEXER_TOP_K,      hparams.indexer_top_k);
@@ -166,7 +167,7 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
         output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, TENSOR_DUPLICATED);
     }
 
-    // flat [ple_head_dim, n_rows] gather target
+    // flat joined table or one table per n-gram head
     if (hparams.ple_n_heads > 0) {
         // the head ranges are what the gather indexes, so they set the minimum row count
         int64_t ple_rows = 0;
@@ -177,31 +178,43 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
         // the converter pads the table; a model synthesised from metadata has no tensor to ask
         const std::string ple_name = tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight").str();
         int64_t table_rows = 0;
+        bool has_joined = false;
         if (ml.files.empty()) {
             // llama_model_init_from_user() carries tensor overrides directly in
             // the caller-owned GGUF context and intentionally has no file-backed
             // weight map.
             const int64_t tid = gguf_find_tensor(ml.metadata, ple_name.c_str());
-            if (tid < 0) {
-                throw std::runtime_error(format("PLE tensor '%s' not found", ple_name.c_str()));
+            if (tid >= 0) {
+                table_rows = gguf_get_tensor_ne(ml.metadata, tid)[1];
+                has_joined = true;
             }
-            table_rows = gguf_get_tensor_ne(ml.metadata, tid)[1];
         } else if (const auto * ple_w = ml.get_weight(ple_name.c_str())) {
             // A file-backed PLE table may live in any shard, so use the unified
             // weight map instead of looking only in the first GGUF context.
             table_rows = ple_w->tensor->ne[1];
+            has_joined = true;
         }
-        if (table_rows > 0) {
+        if (has_joined) {
             if (table_rows < ple_rows) {
                 throw std::runtime_error(format("%s has %" PRId64 " rows, too few for the PLE head ranges (%" PRId64 ")",
                                                 ple_name.c_str(), table_rows, ple_rows));
             }
             ple_rows = table_rows;
+            per_layer_tok_embd = create_tensor(tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"),
+                                               { hparams.ple_head_dim, ple_rows }, TENSOR_READ_LAZY);
+        } else {
+            ple_ngram_embd.resize(hparams.ple_n_heads);
+            for (uint32_t h = 0; h < hparams.ple_n_heads; ++h) {
+                ple_ngram_embd[h] = create_tensor(tn(LLM_TENSOR_PLE_NGRAM_EMBD, "weight", h),
+                                                  { hparams.ple_head_dim, (int64_t) hparams.ple_head_vocab_sizes[h] }, 0);
+            }
         }
-
-        per_layer_tok_embd = create_tensor(tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"),
-                                           { hparams.ple_head_dim, ple_rows }, TENSOR_READ_LAZY);
     }
+
+    // An MTP-only file carries just the draft block. Keep walking the trunk so the
+    // per-layer bookkeeping still runs, but let its tensors be absent.
+    const bool mtp_only = hparams.n_layer_nextn > 0 && ml.get_weight("blk.0.hc_attn_norm.weight") == nullptr;
+    const int  trunk_flags = mtp_only ? TENSOR_NOT_REQUIRED : 0;
 
     for (int il = 0; il < n_layer; ++il) {
         auto & layer = layers[il];
@@ -218,61 +231,109 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
         const int64_t conv_dim   = key_dim * 2 + value_dim;
 
         // two HC modules per layer: before the token mixer, before the MoE
-        layer.hc_attn_norm   = create_tensor(tn(LLM_TENSOR_HC_ATTN_NORM,   "weight", il), { hc_dim }, 0);
-        layer.hc_attn_down   = create_tensor(tn(LLM_TENSOR_HC_ATTN_DOWN,   "weight", il), { hc_dim, hc_lr }, 0);
-        layer.hc_attn_up     = create_tensor(tn(LLM_TENSOR_HC_ATTN_UP,     "weight", il), { hc_lr, hc_dim }, 0);
-        layer.hc_attn_inject = create_tensor(tn(LLM_TENSOR_HC_ATTN_INJECT, "weight", il), { hc_dim, hc }, 0);
-        layer.hc_ffn_norm    = create_tensor(tn(LLM_TENSOR_HC_FFN_NORM,    "weight", il), { hc_dim }, 0);
-        layer.hc_ffn_down    = create_tensor(tn(LLM_TENSOR_HC_FFN_DOWN,    "weight", il), { hc_dim, hc_lr }, 0);
-        layer.hc_ffn_up      = create_tensor(tn(LLM_TENSOR_HC_FFN_UP,      "weight", il), { hc_lr, hc_dim }, 0);
-        layer.hc_ffn_inject  = create_tensor(tn(LLM_TENSOR_HC_FFN_INJECT,  "weight", il), { hc_dim, hc }, 0);
+        layer.hc_attn_norm   = create_tensor(tn(LLM_TENSOR_HC_ATTN_NORM,   "weight", il), { hc_dim }, trunk_flags);
+        layer.hc_attn_down   = create_tensor(tn(LLM_TENSOR_HC_ATTN_DOWN,   "weight", il), { hc_dim, hc_lr }, trunk_flags);
+        layer.hc_attn_up     = create_tensor(tn(LLM_TENSOR_HC_ATTN_UP,     "weight", il), { hc_lr, hc_dim }, trunk_flags);
+        layer.hc_attn_inject = create_tensor(tn(LLM_TENSOR_HC_ATTN_INJECT, "weight", il), { hc_dim, hc }, trunk_flags);
+        layer.hc_ffn_norm    = create_tensor(tn(LLM_TENSOR_HC_FFN_NORM,    "weight", il), { hc_dim }, trunk_flags);
+        layer.hc_ffn_down    = create_tensor(tn(LLM_TENSOR_HC_FFN_DOWN,    "weight", il), { hc_dim, hc_lr }, trunk_flags);
+        layer.hc_ffn_up      = create_tensor(tn(LLM_TENSOR_HC_FFN_UP,      "weight", il), { hc_lr, hc_dim }, trunk_flags);
+        layer.hc_ffn_inject  = create_tensor(tn(LLM_TENSOR_HC_FFN_INJECT,  "weight", il), { hc_dim, hc }, trunk_flags);
 
         if (!hparams.is_recr(il)) {
             // full attention: wq holds [q|gate] interleaved per head
-            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, 0);
-            layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", il), { n_embd_head_k * n_head, n_embd }, 0);
+            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, trunk_flags);
+            layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", il), { n_embd_head_k * n_head, n_embd }, trunk_flags);
 
-            layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", il), { n_embd_head_k }, 0);
-            layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", il), { n_embd_head_k }, 0);
+            layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", il), { n_embd_head_k }, trunk_flags);
+            layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", il), { n_embd_head_k }, trunk_flags);
 
             const int64_t idx_dim = hparams.indexer_head_size;
-            layer.index_q_proj = create_tensor(tn(LLM_TENSOR_INDEXER_Q_PROJ, "weight", il), { n_embd, hparams.indexer_n_head * idx_dim }, 0);
-            layer.index_k_proj = create_tensor(tn(LLM_TENSOR_INDEXER_K_PROJ, "weight", il), { n_embd, idx_dim }, 0);
-            layer.index_q_norm = create_tensor(tn(LLM_TENSOR_INDEXER_Q_NORM, "weight", il), { idx_dim }, 0);
-            layer.index_k_norm = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM, "weight", il), { idx_dim }, 0);
+            layer.index_q_proj = create_tensor(tn(LLM_TENSOR_INDEXER_Q_PROJ, "weight", il), { n_embd, hparams.indexer_n_head * idx_dim }, trunk_flags);
+            layer.index_k_proj = create_tensor(tn(LLM_TENSOR_INDEXER_K_PROJ, "weight", il), { n_embd, idx_dim }, trunk_flags);
+            layer.index_q_norm = create_tensor(tn(LLM_TENSOR_INDEXER_Q_NORM, "weight", il), { idx_dim }, trunk_flags);
+            layer.index_k_norm = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM, "weight", il), { idx_dim }, trunk_flags);
         } else {
-            layer.wqkv       = create_tensor(tn(LLM_TENSOR_ATTN_QKV,   "weight", il), { n_embd, key_dim * 2 + value_dim }, 0);
-            layer.wqkv_gate  = create_tensor(tn(LLM_TENSOR_ATTN_GATE,  "weight", il), { n_embd, value_dim }, 0);
-            layer.ssm_conv1d = create_tensor(tn(LLM_TENSOR_SSM_CONV1D, "weight", il), { hparams.ssm_d_conv, conv_dim }, 0);
-            layer.ssm_dt     = create_tensor(tn(LLM_TENSOR_SSM_DT,     "bias",   il), { hparams.ssm_dt_rank }, 0);
-            layer.ssm_a      = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,         il), { hparams.ssm_dt_rank }, 0);
-            layer.ssm_beta   = create_tensor(tn(LLM_TENSOR_SSM_BETA,   "weight", il), { n_embd, n_v_heads }, 0);
-            layer.ssm_alpha  = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,  "weight", il), { n_embd, n_v_heads }, 0);
-            layer.ssm_norm   = create_tensor(tn(LLM_TENSOR_SSM_NORM,   "weight", il), { head_v_dim }, 0);
-            layer.ssm_out    = create_tensor(tn(LLM_TENSOR_SSM_OUT,    "weight", il), { value_dim, n_embd }, 0);
+            layer.wqkv       = create_tensor(tn(LLM_TENSOR_ATTN_QKV,   "weight", il), { n_embd, key_dim * 2 + value_dim }, trunk_flags);
+            layer.wqkv_gate  = create_tensor(tn(LLM_TENSOR_ATTN_GATE,  "weight", il), { n_embd, value_dim }, trunk_flags);
+            layer.ssm_conv1d = create_tensor(tn(LLM_TENSOR_SSM_CONV1D, "weight", il), { hparams.ssm_d_conv, conv_dim }, trunk_flags);
+            layer.ssm_dt     = create_tensor(tn(LLM_TENSOR_SSM_DT,     "bias",   il), { hparams.ssm_dt_rank }, trunk_flags);
+            layer.ssm_a      = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,         il), { hparams.ssm_dt_rank }, trunk_flags);
+            layer.ssm_beta   = create_tensor(tn(LLM_TENSOR_SSM_BETA,   "weight", il), { n_embd, n_v_heads }, trunk_flags);
+            layer.ssm_alpha  = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,  "weight", il), { n_embd, n_v_heads }, trunk_flags);
+            layer.ssm_norm   = create_tensor(tn(LLM_TENSOR_SSM_NORM,   "weight", il), { head_v_dim }, trunk_flags);
+            layer.ssm_out    = create_tensor(tn(LLM_TENSOR_SSM_OUT,    "weight", il), { value_dim, n_embd }, trunk_flags);
         }
 
         if (hparams.is_ple(il)) {
-            layer.ple_key        = create_tensor(tn(LLM_TENSOR_PLE_KEY,        "weight", il), { n_embd, hc_dim }, 0);
-            layer.ple_value      = create_tensor(tn(LLM_TENSOR_PLE_VALUE,      "weight", il), { n_embd, n_embd }, 0);
-            layer.ple_norm_key   = create_tensor(tn(LLM_TENSOR_PLE_NORM_KEY,   "weight", il), { hc_dim }, 0);
-            layer.ple_norm_query = create_tensor(tn(LLM_TENSOR_PLE_NORM_QUERY, "weight", il), { hc_dim }, 0);
-            layer.ple_norm_conv  = create_tensor(tn(LLM_TENSOR_PLE_NORM_CONV,  "weight", il), { hc_dim }, 0);
-            layer.ple_conv1d     = create_tensor(tn(LLM_TENSOR_PLE_CONV1D,     "weight", il), { hparams.ple_conv_kernel, hc_dim }, 0);
+            layer.ple_key        = create_tensor(tn(LLM_TENSOR_PLE_KEY,        "weight", il), { n_embd, hc_dim }, trunk_flags);
+            layer.ple_value      = create_tensor(tn(LLM_TENSOR_PLE_VALUE,      "weight", il), { n_embd, n_embd }, trunk_flags);
+            layer.ple_norm_key   = create_tensor(tn(LLM_TENSOR_PLE_NORM_KEY,   "weight", il), { hc_dim }, trunk_flags);
+            layer.ple_norm_query = create_tensor(tn(LLM_TENSOR_PLE_NORM_QUERY, "weight", il), { hc_dim }, trunk_flags);
+            layer.ple_norm_conv  = create_tensor(tn(LLM_TENSOR_PLE_NORM_CONV,  "weight", il), { hc_dim }, trunk_flags);
+            layer.ple_conv1d     = create_tensor(tn(LLM_TENSOR_PLE_CONV1D,     "weight", il), { hparams.ple_conv_kernel, hc_dim }, trunk_flags);
         }
 
-        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", il), { n_embd, n_expert }, 0);
-        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", il), { n_ff_exp, n_embd, n_expert }, 0);
-        create_tensor_gate_up_exps(layer, il, n_embd, n_ff_exp, n_expert, 0);
+        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", il), { n_embd, n_expert }, trunk_flags);
+        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", il), { n_ff_exp, n_embd, n_expert }, trunk_flags);
+        create_tensor_gate_up_exps(layer, il, n_embd, n_ff_exp, n_expert, trunk_flags);
 
-        layer.ffn_gate_inp_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP_SHEXP, "weight", il), { n_embd }, 0);
-        layer.ffn_gate_shexp     = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP,     "weight", il), { n_embd, n_ff_shexp }, 0);
-        layer.ffn_up_shexp       = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,       "weight", il), { n_embd, n_ff_shexp }, 0);
-        layer.ffn_down_shexp     = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP,     "weight", il), { n_ff_shexp, n_embd }, 0);
+        layer.ffn_gate_inp_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP_SHEXP, "weight", il), { n_embd }, trunk_flags);
+        layer.ffn_gate_shexp     = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP,     "weight", il), { n_embd, n_ff_shexp }, trunk_flags);
+        layer.ffn_up_shexp       = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,       "weight", il), { n_embd, n_ff_shexp }, trunk_flags);
+        layer.ffn_down_shexp     = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP,     "weight", il), { n_ff_shexp, n_embd }, trunk_flags);
+    }
+
+    // The MTP draft block sits one past the trunk. It is a full qwen4exp layer plus the
+    // three nextn tensors, and is skipped unless the file is opened as a draft.
+    for (int il = n_layer; il < n_layer + (int) hparams.n_layer_nextn; ++il) {
+        auto & layer = layers[il];
+
+        const int flags = ml.load_mtp ? 0 : TENSOR_SKIP;
+        const int64_t n_ff_exp   = hparams.n_ff_exp   ? hparams.n_ff_exp   : n_ff / n_expert_used;
+        const int64_t n_ff_shexp = hparams.n_ff_shexp ? hparams.n_ff_shexp : n_ff;
+        const int64_t idx_dim    = hparams.indexer_head_size;
+
+        layer.hc_attn_norm   = create_tensor(tn(LLM_TENSOR_HC_ATTN_NORM,   "weight", il), { hc_dim }, flags);
+        layer.hc_attn_down   = create_tensor(tn(LLM_TENSOR_HC_ATTN_DOWN,   "weight", il), { hc_dim, hc_lr }, flags);
+        layer.hc_attn_up     = create_tensor(tn(LLM_TENSOR_HC_ATTN_UP,     "weight", il), { hc_lr, hc_dim }, flags);
+        layer.hc_attn_inject = create_tensor(tn(LLM_TENSOR_HC_ATTN_INJECT, "weight", il), { hc_dim, hc }, flags);
+        layer.hc_ffn_norm    = create_tensor(tn(LLM_TENSOR_HC_FFN_NORM,    "weight", il), { hc_dim }, flags);
+        layer.hc_ffn_down    = create_tensor(tn(LLM_TENSOR_HC_FFN_DOWN,    "weight", il), { hc_dim, hc_lr }, flags);
+        layer.hc_ffn_up      = create_tensor(tn(LLM_TENSOR_HC_FFN_UP,      "weight", il), { hc_lr, hc_dim }, flags);
+        layer.hc_ffn_inject  = create_tensor(tn(LLM_TENSOR_HC_FFN_INJECT,  "weight", il), { hc_dim, hc }, flags);
+
+        create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, flags);
+        layer.wo          = create_tensor(tn(LLM_TENSOR_ATTN_OUT,    "weight", il), { n_embd_head_k * n_head, n_embd }, flags);
+        layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", il), { n_embd_head_k }, flags);
+        layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", il), { n_embd_head_k }, flags);
+
+        // The draft attends dense, so the indexer weights are present but never read.
+        const int idx_flags = flags | TENSOR_NOT_REQUIRED | TENSOR_SKIP;
+        layer.index_q_proj = create_tensor(tn(LLM_TENSOR_INDEXER_Q_PROJ, "weight", il), { n_embd, hparams.indexer_n_head * idx_dim }, idx_flags);
+        layer.index_k_proj = create_tensor(tn(LLM_TENSOR_INDEXER_K_PROJ, "weight", il), { n_embd, idx_dim }, idx_flags);
+        layer.index_q_norm = create_tensor(tn(LLM_TENSOR_INDEXER_Q_NORM, "weight", il), { idx_dim }, idx_flags);
+        layer.index_k_norm = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM, "weight", il), { idx_dim }, idx_flags);
+
+        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", il), { n_embd, n_expert }, flags);
+        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", il), { n_ff_exp, n_embd, n_expert }, flags);
+        create_tensor_gate_up_exps(layer, il, n_embd, n_ff_exp, n_expert, flags);
+
+        layer.ffn_gate_inp_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP_SHEXP, "weight", il), { n_embd }, flags);
+        layer.ffn_gate_shexp     = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP,     "weight", il), { n_embd, n_ff_shexp }, flags);
+        layer.ffn_up_shexp       = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,       "weight", il), { n_embd, n_ff_shexp }, flags);
+        layer.ffn_down_shexp     = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP,     "weight", il), { n_ff_shexp, n_embd }, flags);
+
+        layer.nextn.enorm   = create_tensor(tn(LLM_TENSOR_NEXTN_ENORM,   "weight", il), { n_embd }, flags);
+        layer.nextn.hnorm   = create_tensor(tn(LLM_TENSOR_NEXTN_HNORM,   "weight", il), { hc_dim }, flags);
+        layer.nextn.eh_proj = create_tensor(tn(LLM_TENSOR_NEXTN_EH_PROJ, "weight", il), { 2 * n_embd, n_embd }, flags);
     }
 }
 
 std::unique_ptr<llm_graph_context> llama_model_qwen4exp::build_arch_graph(const llm_graph_params & params) const {
+    if (params.gtype == LLM_GRAPH_TYPE_DECODER_MTP) {
+        return std::make_unique<graph_mtp>(*this, params);
+    }
     return std::make_unique<graph>(*this, params);
 }
 
@@ -348,6 +409,10 @@ ggml_tensor * llama_model_qwen4exp::graph::build_hc_combine(
     return cur;
 }
 
+// Members only: graph_mtp builds a single block instead of the trunk.
+llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_params & params, bool) :
+    llm_build_delta_net_base(params), model(model) {}
+
 llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_params & params) :
     llm_build_delta_net_base(params), model(model) {
     const int64_t hc = hparams.dsv4_hc_mult;
@@ -412,7 +477,8 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
             cur = build_layer_attn(inp->get_attn(), mctx_hyb, cur, inp_pos, sections, il);
         }
 
-        if (il == n_layer - 1 && inp_out_ids) {
+        if (il == n_layer - 1 && inp_out_ids &&
+                (!cparams.embeddings_nextn || cparams.embeddings_nextn_masked)) {
             // everything below is per token, so drop the rows that produce no output
             cur    = ggml_get_rows(ctx0, cur,    inp_out_ids);
             inject = ggml_get_rows(ctx0, inject, inp_out_ids);
@@ -440,11 +506,122 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
         cb(res_hc, "l_last", il);
     }
 
+    // The draft head consumes the final wide residual, before the LM-head mixer collapses it.
+    // An unmasked request needs every position, so defer the output-row crop until after this
+    // hand-over.
+    if (cparams.embeddings_nextn) {
+        res->t_h_nextn = res_hc;
+        cb(res->t_h_nextn, "h_nextn", -1);
+
+        if (!cparams.embeddings_nextn_masked && inp_out_ids) {
+            res_hc = ggml_reshape_2d(ctx0, res_hc, n_embd*hc, res_hc->ne[2]);
+            res_hc = ggml_get_rows(ctx0, res_hc, inp_out_ids);
+            res_hc = ggml_reshape_3d(ctx0, res_hc, n_embd, hc, res_hc->ne[1]);
+        }
+    }
+
     // the final mixer is the output norm: there is no separate one
     ggml_tensor * cur = build_hc_mix(res_hc,
             model.hc_head_norm, model.hc_head_down, model.hc_head_up,
             nullptr, nullptr, -1);
 
+    cb(cur, "result_norm", -1);
+    res->t_embd = cur;
+
+    cur = build_lora_mm(model.output, cur, model.output_s);
+    cb(cur, "result_output", -1);
+    res->t_logits = cur;
+
+    ggml_build_forward_expand(gf, cur);
+}
+
+// Port of the qwen4exp MTP block from JJJYmmm's PR 27739, including the
+// grouped hidden-state RMSNorm and final-residual hand-over corrections.
+llama_model_qwen4exp::graph_mtp::graph_mtp(const llama_model & model, const llm_graph_params & params)
+    : graph(model, params, true) {
+    GGML_ASSERT(hparams.n_layer_nextn == 1 && "qwen4exp MTP supports a single block");
+    GGML_ASSERT(ubatch.token && "qwen4exp MTP needs token input");
+
+    const int64_t hc     = hparams.dsv4_hc_mult;
+    const int64_t n_embd = hparams.n_embd;
+
+    const int    il    = hparams.n_layer();
+    const auto & layer = model.layers[il];
+
+    GGML_ASSERT(layer.nextn.eh_proj && "MTP block is missing nextn.eh_proj");
+    GGML_ASSERT(layer.nextn.enorm   && "MTP block is missing nextn.enorm");
+    GGML_ASSERT(layer.nextn.hnorm   && "MTP block is missing nextn.hnorm");
+
+    int sections[4];
+    std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
+
+    auto inp = std::make_unique<llm_graph_input_embd_h>(hparams.n_embd_out());
+
+    inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_tokens);
+    ggml_set_input(inp->tokens);
+
+    inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_out(), n_tokens);
+    ggml_set_input(inp->embd);
+
+    inp->h = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_out(), n_tokens);
+    ggml_set_input(inp->h);
+    ggml_set_name(inp->h, "mtp_h_input");
+
+    ggml_tensor * tok_embd = ggml_get_rows(ctx0, model.tok_embd, inp->tokens);
+    cb(tok_embd, "mtp_tok_embd", il);
+
+    ggml_tensor * h = inp->h;
+    res->add_input(std::move(inp));
+
+    ggml_tensor * inp_pos     = build_inp_pos();
+    ggml_tensor * inp_out_ids = build_inp_out_ids();
+    auto        * inp_attn    = build_attn_inp_kv();
+
+    // Normalize each hyper-connection stream over n_embd, then apply the full-row gamma.
+    ggml_tensor * h_norm = ggml_reshape_3d(ctx0, h, n_embd, hc, n_tokens);
+    h_norm = ggml_rms_norm(ctx0, h_norm, hparams.f_norm_rms_eps);
+    h_norm = ggml_reshape_2d(ctx0, h_norm, hc*n_embd, n_tokens);
+    h_norm = ggml_mul(ctx0, h_norm, layer.nextn.hnorm);
+    h_norm = ggml_reshape_3d(ctx0, h_norm, n_embd, hc, n_tokens);
+    cb(h_norm, "mtp_hnorm", il);
+
+    ggml_tensor * e_norm = build_norm(tok_embd, layer.nextn.enorm, nullptr, LLM_NORM_RMS, il);
+    e_norm = ggml_repeat_4d(ctx0, ggml_reshape_3d(ctx0, e_norm, n_embd, 1, n_tokens), n_embd, hc, n_tokens, 1);
+    cb(e_norm, "mtp_enorm", il);
+
+    ggml_tensor * inpL = build_lora_mm(layer.nextn.eh_proj,
+            ggml_concat(ctx0, e_norm, h_norm, 0), layer.nextn.eh_proj_s);
+    cb(inpL, "mtp_eh_proj", il);
+
+    ggml_tensor * inject = nullptr;
+    ggml_tensor * cur    = build_hc_mix(inpL,
+            layer.hc_attn_norm, layer.hc_attn_down, layer.hc_attn_up, layer.hc_attn_inject, &inject, il);
+    cb(cur, "mtp_hc_attn_pre", il);
+
+    // The one-block draft attends densely and therefore needs no QSA indexer cache.
+    cur = build_layer_attn(inp_attn, nullptr, cur, inp_pos, sections, il);
+    inpL = build_hc_combine(inpL, cur, inject, il);
+    cb(inpL, "mtp_hc_attn_post", il);
+
+    cur = build_hc_mix(inpL,
+            layer.hc_ffn_norm, layer.hc_ffn_down, layer.hc_ffn_up, layer.hc_ffn_inject, &inject, il);
+    cb(cur, "mtp_hc_ffn_pre", il);
+
+    cur = build_layer_ffn(cur, il);
+    cb(cur, "mtp_ffn_out", il);
+
+    inpL = build_hc_combine(inpL, cur, inject, il);
+    cb(inpL, "mtp_l_out", il);
+
+    ggml_tensor * flat = ggml_reshape_2d(ctx0, inpL, hc*n_embd, n_tokens);
+    res->t_h_nextn = flat;
+
+    if (inp_out_ids) {
+        flat = ggml_get_rows(ctx0, flat, inp_out_ids);
+        inpL = ggml_reshape_3d(ctx0, flat, n_embd, hc, n_outputs);
+    }
+
+    cur = build_hc_mix(inpL, model.hc_head_norm, model.hc_head_down, model.hc_head_up, nullptr, nullptr, -1);
     cb(cur, "result_norm", -1);
     res->t_embd = cur;
 
@@ -780,8 +957,8 @@ ggml_tensor * llama_model_qwen4exp::graph::build_layer_attn(
     const int64_t n_embd_head = hparams.n_embd_head_v();
     GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
 
-    // indexer reads the same block input as q/k/v; no cache or no ratio means dense
-    const bool qsa = mctx_hyb->get_idx() != nullptr && hparams.dsv4_compress_ratios[il] > 0;
+    // The MTP draft passes no hybrid context and attends densely.
+    const bool qsa = mctx_hyb != nullptr && mctx_hyb->get_idx() != nullptr && hparams.dsv4_compress_ratios[il] > 0;
 
     ggml_tensor * top_k = qsa ? build_qsa_top_k(mctx_hyb, cur, inp_pos, inp->get_kq_mask(), sections, il) : nullptr;
 
@@ -1079,6 +1256,7 @@ void llm_graph_input_ple::set_input(const llama_ubatch * ubatch) {
     const int64_t per_gram = hp.ple_heads_per_ngram;
     const int64_t eos      = hp.ple_eos_token_id;
     const int64_t n_prev   = n_gram - 1;
+    const bool split       = !pmodel.ple_ngram_embd.empty();
 
     std::vector<int32_t> idx(n_heads * n_tokens);
 
@@ -1114,8 +1292,8 @@ void llm_graph_input_ple::set_input(const llama_ubatch * ubatch) {
             const int64_t base = (n - 2) * per_gram;
             for (int64_t g = 0; g < per_gram; ++g) {
                 const int64_t h_i = base + g;
-                idx[i * n_heads + h_i] =
-                    (int32_t) (mixed % hp.ple_head_vocab_sizes[h_i] + hp.ple_head_offsets[h_i]);
+                const uint64_t local = mixed % hp.ple_head_vocab_sizes[h_i];
+                idx[i * n_heads + h_i] = (int32_t) (split ? local : local + hp.ple_head_offsets[h_i]);
             }
         }
     }
@@ -1193,7 +1371,18 @@ ggml_tensor * llama_model_qwen4exp::graph::build_inp_ple(
     res->add_input(std::move(ple_inp));
 
     // gather then flatten the heads: get_rows lays the head dimension out slowest, as the reference does
-    ggml_tensor * emb = ggml_get_rows(ctx0, model.per_layer_tok_embd, rows);
+    ggml_tensor * emb = nullptr;
+    if (model.ple_ngram_embd.empty()) {
+        emb = ggml_get_rows(ctx0, model.per_layer_tok_embd, rows);
+    } else {
+        ggml_tensor * rows_2d = ggml_reshape_2d(ctx0, rows, n_heads, n_tokens);
+        for (int64_t h = 0; h < n_heads; ++h) {
+            ggml_tensor * idx = ggml_view_2d(ctx0, rows_2d, 1, n_tokens, rows_2d->nb[1], h * rows_2d->nb[0]);
+            idx = ggml_reshape_1d(ctx0, ggml_cont(ctx0, idx), n_tokens);
+            ggml_tensor * emb_head = ggml_get_rows(ctx0, model.ple_ngram_embd[h], idx);
+            emb = emb ? ggml_concat(ctx0, emb, emb_head, 0) : emb_head;
+        }
+    }
     emb = ggml_reshape_2d(ctx0, emb, hparams.ple_head_dim * n_heads, n_tokens);
     cb(emb, "ple_embd", -1);
 

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -53,7 +53,9 @@ void llama_model_qwen4exp::load_arch_hparams(llama_model_loader & ml) {
     qwen4exp_require_nonzero(ml, LLM_KV_HYPER_CONNECTION_LOW_RANK, hparams.hc_low_rank);
     hparams.n_embd_out_impl = hparams.dsv4_hc_mult * hparams.n_embd;
 
-    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
+    if (hparams.n_layer_nextn > 1 || hparams.n_layer_nextn == hparams.n_layer_all) {
+        throw std::runtime_error("qwen4exp requires trunk layers and supports at most one MTP layer");
+    }
     ml.get_key(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT, hparams.indexer_n_head);
     ml.get_key(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH, hparams.indexer_head_size);
     ml.get_key(LLM_KV_ATTENTION_INDEXER_TOP_K,      hparams.indexer_top_k);
@@ -203,9 +205,13 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
             per_layer_tok_embd = create_tensor(tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"),
                                                { hparams.ple_head_dim, ple_rows }, TENSOR_READ_LAZY);
         } else {
+            uint32_t ple_layer = 0;
+            while (ple_layer < hparams.n_layer_all && !hparams.is_ple(ple_layer)) {
+                ++ple_layer;
+            }
             ple_ngram_embd.resize(hparams.ple_n_heads);
             for (uint32_t h = 0; h < hparams.ple_n_heads; ++h) {
-                ple_ngram_embd[h] = create_tensor(tn(LLM_TENSOR_PLE_NGRAM_EMBD, "weight", h),
+                ple_ngram_embd[h] = create_tensor(tn(LLM_TENSOR_PLE_NGRAM_EMBD, "weight", ple_layer, h),
                                                   { hparams.ple_head_dim, (int64_t) hparams.ple_head_vocab_sizes[h] }, 0);
             }
         }
@@ -213,7 +219,11 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
 
     // An MTP-only file carries just the draft block. Keep walking the trunk so the
     // per-layer bookkeeping still runs, but let its tensors be absent.
-    const bool mtp_only = hparams.n_layer_nextn > 0 && ml.get_weight("blk.0.hc_attn_norm.weight") == nullptr;
+    const bool mtp_only = !ml.files.empty() && hparams.n_layer_nextn > 0 &&
+                         ml.get_weight("blk.0.hc_attn_norm.weight") == nullptr;
+    if (mtp_only && !ml.load_mtp) {
+        throw std::runtime_error("qwen4exp MTP-only weights must be loaded as a draft model");
+    }
     const int  trunk_flags = mtp_only ? TENSOR_NOT_REQUIRED : 0;
 
     for (int il = 0; il < n_layer; ++il) {
@@ -287,9 +297,12 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
     // The MTP draft block sits one past the trunk. It is a full qwen4exp layer plus the
     // three nextn tensors, and is skipped unless the file is opened as a draft.
     for (int il = n_layer; il < n_layer + (int) hparams.n_layer_nextn; ++il) {
+        if (ml.files.empty() && !ml.load_mtp) {
+            continue;
+        }
         auto & layer = layers[il];
 
-        const int flags = ml.load_mtp ? 0 : TENSOR_SKIP;
+        const int flags = ml.load_mtp ? 0 : TENSOR_SKIP | TENSOR_SKIP_IF_VIRTUAL;
         const int64_t n_ff_exp   = hparams.n_ff_exp   ? hparams.n_ff_exp   : n_ff / n_expert_used;
         const int64_t n_ff_shexp = hparams.n_ff_shexp ? hparams.n_ff_shexp : n_ff;
         const int64_t idx_dim    = hparams.indexer_head_size;
@@ -309,7 +322,7 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
         layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", il), { n_embd_head_k }, flags);
 
         // The draft attends dense, so the indexer weights are present but never read.
-        const int idx_flags = flags | TENSOR_NOT_REQUIRED | TENSOR_SKIP;
+        const int idx_flags = flags | TENSOR_NOT_REQUIRED | TENSOR_SKIP | TENSOR_SKIP_IF_VIRTUAL;
         layer.index_q_proj = create_tensor(tn(LLM_TENSOR_INDEXER_Q_PROJ, "weight", il), { n_embd, hparams.indexer_n_head * idx_dim }, idx_flags);
         layer.index_k_proj = create_tensor(tn(LLM_TENSOR_INDEXER_K_PROJ, "weight", il), { n_embd, idx_dim }, idx_flags);
         layer.index_q_norm = create_tensor(tn(LLM_TENSOR_INDEXER_Q_NORM, "weight", il), { idx_dim }, idx_flags);

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -9,6 +9,7 @@
 
 // TODO: replace with #include "llama-ext.h" in the future
 #include "../src/llama-arch.h"
+#include "../src/llama-ext.h"
 #include "../src/llama-model-saver.h"
 
 #include <cinttypes>
@@ -42,9 +43,17 @@ static double nmse(const std::vector<float> & a, const std::vector<float> & b) {
 static void set_tensor_data(struct ggml_tensor * tensor, void * userdata) {
     size_t seed = *(const size_t *) userdata;
     std::hash<std::string> hasher;
-    seed ^= hasher(tensor->name);
+    int ple_head = -1;
+    const bool split_ple = std::sscanf(tensor->name, "ple_ngram_embd.%d.weight", &ple_head) == 1;
+    seed ^= hasher(split_ple ? "per_layer_token_embd.weight" : tensor->name);
     std::mt19937 gen(seed);
     std::normal_distribution<float> dis(0.0f, 1.0e-2f);
+    // Match the corresponding 16-row range of the joined PLE fixture.
+    if (split_ple) {
+        for (int i = 0; i < ple_head * 16 * 64; ++i) {
+            dis(gen);
+        }
+    }
 
     const int64_t ne = ggml_nelements(tensor);
     if (tensor->type == GGML_TYPE_F32) {
@@ -89,7 +98,7 @@ static std::vector<llama_token> get_tokens(const uint32_t n_tokens, const uint32
     return ret;
 }
 
-static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
+static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe, const bool split_ple = false, const bool mtp = false) {
     gguf_context_ptr ret(gguf_init_empty());
     llama_model_saver ms(arch, ret.get());
     const uint32_t n_ctx = 256;
@@ -98,7 +107,7 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
     uint32_t n_embd  = 256;
     uint32_t n_head  = 2;
     uint32_t n_ff    = 384;
-    uint32_t n_layer = 2;
+    uint32_t n_layer = mtp ? 3 : 2;
     if (arch == LLM_ARCH_LLAMA4) {
         n_layer = 4; // hparams.n_no_rope_layer_step is hard-coded to 4
     } else if (arch == LLM_ARCH_GEMMA4) {
@@ -260,6 +269,7 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
     // MSA requires one indexer head per GQA (KV) head, unlike the DSA archs where the
     // indexer head count is independent of the main attention head count.
     if (arch == LLM_ARCH_QWEN4EXP) {
+        ms.add_kv(LLM_KV_NEXTN_PREDICT_LAYERS, uint32_t(mtp ? 1 : 0));
         ms.add_kv(LLM_KV_HYPER_CONNECTION_COUNT,    uint32_t(4));
         ms.add_kv(LLM_KV_HYPER_CONNECTION_LOW_RANK, uint32_t(8));
         // without this the QSA layers fall back to dense and go uncovered
@@ -366,13 +376,19 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         gguf_add_tensor(ms.gguf_ctx, &t);
     }
     if (arch == LLM_ARCH_QWEN4EXP) {
-        const size_t ctx_size = ggml_tensor_overhead() + 1024;
+        const size_t ctx_size = 4 * ggml_tensor_overhead() + 1024;
         ggml_init_params params = { ctx_size, nullptr, true };
         ggml_context * ctx = ggml_init(params);
         GGML_ASSERT(ctx != nullptr);
-        ggml_tensor * table = ggml_new_tensor_2d(ctx, GGML_TYPE_Q3_0_ROCMFPX, 64, 64);
-        ggml_set_name(table, "per_layer_token_embd.weight");
-        gguf_add_tensor(ms.gguf_ctx, table);
+        for (int h = 0; h < (split_ple ? 4 : 1); ++h) {
+            ggml_tensor * table = ggml_new_tensor_2d(ctx, GGML_TYPE_Q3_0_ROCMFPX, 64, split_ple ? 16 : 64);
+            if (split_ple) {
+                ggml_format_name(table, "ple_ngram_embd.%d.weight", h);
+            } else {
+                ggml_set_name(table, "per_layer_token_embd.weight");
+            }
+            gguf_add_tensor(ms.gguf_ctx, table);
+        }
         ggml_free(ctx);
     }
     return ret;
@@ -384,7 +400,7 @@ static bool silent_model_load_progress(float /*progress*/, void * /*user_data*/)
 
 static std::pair<llama_model_ptr, llama_context_ptr> get_model_and_ctx(
         struct gguf_context * gguf_ctx, FILE * file, const size_t seed, const std::vector<ggml_backend_dev_t> & devs,
-        const llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER, bool encode = false) {
+        const llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER, bool encode = false, bool mtp = false) {
     GGML_ASSERT((gguf_ctx == nullptr) != (file == nullptr));
     llama_model_params model_params = llama_model_default_params();
     model_params.progress_callback = silent_model_load_progress;
@@ -392,11 +408,15 @@ static std::pair<llama_model_ptr, llama_context_ptr> get_model_and_ctx(
     devs_copy.push_back(nullptr);
     model_params.devices = devs_copy.data();
     model_params.split_mode = split_mode;
+    model_params.load_mtp = mtp;
 
     llama_context_params ctx_params = llama_context_default_params();
     ctx_params.n_ctx = 0;
     ctx_params.n_threads = 4;
     ctx_params.n_threads_batch = 4;
+    if (mtp) {
+        ctx_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    }
     if (!encode) {
         ctx_params.n_ubatch = 64;
     }
@@ -447,6 +467,72 @@ static std::vector<float> get_logits(
     }
     llama_batch_free(batch);
     return ret;
+}
+
+static int test_qwen4exp_split_ple(const size_t seed) {
+    auto joined = get_gguf_ctx(LLM_ARCH_QWEN4EXP, true);
+    auto split = get_gguf_ctx(LLM_ARCH_QWEN4EXP, true, true);
+    auto cpu = get_model_and_ctx(joined.get(), nullptr, seed, {});
+    const auto tokens = get_tokens(32, 128, seed);
+    const auto reference = get_logits(cpu.first.get(), cpu.second.get(), tokens);
+    auto with_mtp = get_gguf_ctx(LLM_ARCH_QWEN4EXP, true, true, true);
+    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+        auto dev = ggml_backend_dev_get(i);
+        auto model = get_model_and_ctx(split.get(), nullptr, seed, {dev});
+        const auto logits = get_logits(model.first.get(), model.second.get(), tokens);
+        const double error = nmse(reference, logits);
+        if (!(error <= 1e-4)) {
+            std::fprintf(stderr, "FAIL split PLE vs joined on %s: NMSE=%g\n", ggml_backend_dev_name(dev), error);
+            return 1;
+        }
+        FILE * file = tmpfile();
+        if (file) {
+            llama_model_saver saver(model.first.get());
+            saver.add_kv_from_model();
+            saver.add_tensors_from_model();
+            saver.save(file);
+            rewind(file);
+            auto reloaded = get_model_and_ctx(nullptr, file, seed, {dev});
+            const auto roundtrip = get_logits(reloaded.first.get(), reloaded.second.get(), tokens);
+            fclose(file);
+            if (roundtrip != logits) {
+                std::fprintf(stderr, "FAIL split PLE roundtrip on %s\n", ggml_backend_dev_name(dev));
+                return 1;
+            }
+        }
+        std::printf("PASS split PLE on %s: 4 heads / 2 layers, joined NMSE=%g, roundtrip=%s\n",
+                    ggml_backend_dev_name(dev), error, file ? "PASS" : "SKIP");
+
+        auto target = get_model_and_ctx(with_mtp.get(), nullptr, seed, {dev});
+        llama_set_embeddings_nextn(target.second.get(), true, false);
+        const auto target_logits = get_logits(target.first.get(), target.second.get(), tokens);
+        if (!(nmse(logits, target_logits) <= 1e-6)) {
+            std::fprintf(stderr, "FAIL MTP metadata/hidden extraction changed target logits on %s\n", ggml_backend_dev_name(dev));
+            return 1;
+        }
+        auto draft = get_model_and_ctx(with_mtp.get(), nullptr, seed, {dev}, LLAMA_SPLIT_MODE_LAYER, false, true);
+        llama_set_embeddings_nextn(draft.second.get(), true, true);
+        const int n_embd = llama_model_n_embd_out(target.first.get());
+        llama_batch batch = llama_batch_init(1, 0, 1);
+        std::vector<float> hidden(n_embd);
+        std::memcpy(hidden.data(), llama_get_embeddings_nextn_ith(target.second.get(), 0), n_embd * sizeof(float));
+        common_batch_add(batch, tokens[1], 0, {0}, true);
+        batch.embd = hidden.data();
+        const int status = llama_decode(draft.second.get(), batch);
+        batch.embd = nullptr;
+        llama_batch_free(batch);
+        if (status != 0) {
+            throw std::runtime_error("qwen4exp MTP fixture decode failed");
+        }
+        const float * draft_logits = llama_get_logits_ith(draft.second.get(), 0);
+        for (int j = 0; j < 128; ++j) {
+            if (!std::isfinite(draft_logits[j])) {
+                throw std::runtime_error("qwen4exp MTP fixture produced non-finite logits");
+            }
+        }
+        std::printf("PASS MTP target hidden extraction and draft decode on %s\n", ggml_backend_dev_name(dev));
+    }
+    return 0;
 }
 
 static bool moe_mandatory(const llm_arch arch) {
@@ -870,7 +956,11 @@ int main(int argc, char ** argv) {
         if (!out.empty()) {
             return save_models(arch, seed, verbosity, out);
         }
-        return test_backends(arch, seed, verbosity);
+        const int result = test_backends(arch, seed, verbosity);
+        if (result == 0 && arch == LLM_ARCH_QWEN4EXP) {
+            return test_qwen4exp_split_ple(seed);
+        }
+        return result;
     } catch (const std::exception & err) {
         fprintf(stderr, "encountered runtime error: %s\n", err.what());
         return -1;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1146,7 +1146,11 @@ private:
                     SRV_ERR("%s", "Qwen strict MTP requires bounded recurrent rollback covering the full draft\n");
                     return false;
                 }
-                SRV_WRN("%s", "Qwen strict MTP: boundary-safe verification with bounded recurrent rollback is enabled for exact greedy output\n");
+                if (strcmp(model_arch, "qwen4exp") == 0) {
+                    SRV_WRN("%s", "Qwen4Exp MTP: boundary-safe verification and bounded recurrent rollback enabled; quantized batched verification can still differ from serial greedy output. Use --spec-type none when exact serial output is required.\n");
+                } else {
+                    SRV_WRN("%s", "Qwen strict MTP: boundary-safe verification with bounded recurrent rollback is enabled for exact greedy output\n");
+                }
             } else if (is_strict_qwen_arch && has_mtp) {
                 SRV_WRN("%s", "Qwen MTP strict verification is disabled; greedy output may diverge from no-spec decoding (enable --spec-mtp-strict-qwen)\n");
             }


### PR DESCRIPTION
## Scope

Add the missing Qwen4Exp split PLE tables and native NextN/MTP draft graph to ROCmFPX. This enables loading the existing Qwen3.8 Flash Next split-PLE16 target and its separate MTP GGUF. MTP remains opt-in. No default serving settings, quantization layouts, GPU kernels, or upstream-sync workflow are changed.

Retains adaptation commit e811481023ab33b97ebcad1c0e815fb7329059aa, its Marshall author identity, Based-on trailers, and credit to JJJYmmm's original MTP implementation (llama.cpp PR 27739). Material AI assistance: Codex performed integration, follow-up fixes, regression tests, and prepared this PR. The preserved attribution is not a claim of independent human review.

## Follow-up fixes

- Place split PLE tables by their actual model layer, independently of their head names. A four-head/two-layer fixture reproduced an out-of-range exception before the fix.
- Reject unsupported MTP layer counts and accidental use of a draft-only file as a target.
- Exercise joined/split numerical parity, save/reload, target hidden-state extraction, and draft graph execution in the existing architecture test.
- Read draft expert dimensions through the scalar/array GGUF loader. A compatibility build caught the newer upstream expert-size API change; the added block no longer depends on that changed field.

## Validation

- Public base: c3b1c9999b827f5ff4661142e3a0841ab1dc09be.
- ROCmFPX CPU reference, RDNA3 selector controls, ROCmFP2 reference (32,520 checks), GGUF parser, plugin ABI, recipe map: passed locally.
- CPU backend ops: 2,909/2,909 passed.
- Existing llama, qwen35, qwen35moe, and qwen3moe CPU architecture/serialization fixtures passed.
- Final head 47483a0eb8cf6baed7525daf7b8934b40d76d47d: Qwen4Exp split PLE and MTP fixtures passed on CPU and gfx1151 Vulkan. Joined/split NMSE was 0 on CPU and 8.63963e-08 on Vulkan; save/reload was identical on each backend. The last commit corrects the Qwen4Exp warning to disclose possible serial/batched numerical divergence.
- Original contributor ancestry and existing upstream ancestry are retained. The upstream-sync workflow/script are unchanged. A separate local merge with vanilla 6a1a922d269908a29cbd4b49c27e6a8e7fd10fae built and passed the CPU Qwen4Exp split-PLE/MTP fixture. That audit merge is not added to this feature PR.

## Merge gates and limits

Do not merge until required human CODEOWNER approval and the applicable runtime gates pass. Final-head CI passed (run 33976864998). Full-model smoke/benchmarks completed with user-authorized temporary service pauses; the original experimental serving profile was restored afterward. A separate unpublished kernel investigation is not part of this PR.

### Full-model findings and remaining limits

Six sequential profiles on the same target/draft, Vulkan0, 262144 context capacity, greedy sampling and no prompt-cache reuse completed. Candidate MTP decode improved on the tested workloads (short code 53.08 vs 42.84 tok/s; repeated prose 57.88 vs 51.37), but its 8192-input prefill was slower (300.26 vs 388.45 tok/s; TTFT 27.294 vs 21.101 s). MTP+ngram repeated-prose decode was 79.40 candidate vs 107.90 experimental tok/s.

Repeated prose was byte-identical to no-spec on both builds. Output identity was not universal: no-spec cross-build matched 4/5 prompts, MTP cross-build matched 2/6. The comparison includes differences between the old experimental backend/tree and public main, so it does not isolate a regression to this PR. These raw-completion tests did not apply the chat template and are not HumanEval or Hermes-20.

Follow-up tests use the model's proper chat template with enable_thinking=false. Ordinary Vulkan MTP and no-spec are byte-identical on all four chat cases: marker, count, Fibonacci code, and prose. Ordinary Vulkan MTP measured 57.325 tok/s for count, 54.252 for code, and 49.656 for prose. Across ordinary and optional Charlie Vulkan with MTP on/off, three of four cases match universally; Charlie no-spec generates a different valid Fibonacci implementation. The 8192-input varied-prompt prefill remained 300.063 tok/s on ordinary Vulkan MTP versus 319.065 on Charlie MTP.

Controlled runs on the old experimental tree show no meaningful benefit from its QSA pooled-cache switch on these workloads. Disabling its grouped Vulkan tuning switches reduces repetitive decode from 107.366 to 97.013 tok/s and prefill from 386.904 to 352.493 tok/s, with identical output on all six control cases. This accounts for part, not all, of the performance gap. Public native ROCmFPX scalar matrix kernels versus experimental cooperative-matrix kernels are being investigated separately; no such kernels are included here.

Functional split-PLE/MTP and focused regression gates pass. Universal serial-greedy identity and performance parity with the older experimental tree do not. MTP is explicitly opt-in, and no public-main merge or serving-default upgrade has been performed. Required human review is still absent.

The separate opt-in cooperative-matrix experiment completed: repetitive MTP+ngram decode 79.281 -> 89.298 tok/s; 8192-input prefill 300.681 -> 345.443 tok/s; TTFT 27.256 -> 23.725 s. Four chat cases and repeated prose match, but the 8192-input continuation differs with the flag on/off, including without speculation. That experiment remains unpublished and is excluded from this PR; its performance numbers are not results for this PR head.

Historical experimental throughput is not a benchmark result for this PR. Earlier large-model experiments did not establish universal greedy equivalence for MTP, so this PR does not claim globally lossless decoding. HIP full-model MTP, long-context performance, and speculative output quality are not established by a tiny graph fixture. Future upstream merges still require conflict review and regression testing.
